### PR TITLE
remove Mojular:

### DIFF
--- a/mtp_noms_ops/assets-src/javascripts/main.js
+++ b/mtp_noms_ops/assets-src/javascripts/main.js
@@ -1,19 +1,11 @@
 /* globals require */
 
-(function() {
+(function () {
   'use strict';
+  require('security-forms').SecurityForms.init();
+  require('analytics').Analytics.init();
+  require('help-popup').HelpPopup.init();
+  require('collapsing-table').CollapsingTableShowHide.init();
+  require('upload').UploadSubmit.init();
 
-  var Mojular = require('mojular');
-
-  Mojular
-    .use([
-      require('mojular-govuk-elements'),
-      require('mojular-moj-elements'),
-      require('polyfills'),
-      require('collapsing-table'),
-      require('upload'),
-      
-      require('security-forms')
-    ])
-    .init();
-}());
+})();

--- a/mtp_noms_ops/assets-src/stylesheets/app-ie6.scss
+++ b/mtp_noms_ops/assets-src/stylesheets/app-ie6.scss
@@ -1,0 +1,16 @@
+@charset 'UTF-8';
+
+$is-ie: true;
+$ie-version: 6;
+$mobile-ie6: false;
+
+$images-dir: '/static/images/';
+
+@import 'mtp';
+
+form .form-group .form-hint {
+  margin-top: 0;
+}
+
+@import 'views/security-forms';
+@import 'views/security-form-fields';

--- a/mtp_noms_ops/assets-src/stylesheets/app-ie7.scss
+++ b/mtp_noms_ops/assets-src/stylesheets/app-ie7.scss
@@ -1,0 +1,15 @@
+@charset 'UTF-8';
+
+$is-ie: true;
+$ie-version: 7;
+
+$images-dir: '/static/images/';
+
+@import 'mtp';
+
+form .form-group .form-hint {
+  margin-top: 0;
+}
+
+@import 'views/security-forms';
+@import 'views/security-form-fields';

--- a/mtp_noms_ops/assets-src/stylesheets/app-ie8.scss
+++ b/mtp_noms_ops/assets-src/stylesheets/app-ie8.scss
@@ -1,0 +1,15 @@
+@charset 'UTF-8';
+
+$is-ie: true;
+$ie-version: 8;
+
+$images-dir: '/static/images/';
+
+@import 'mtp';
+
+form .form-group .form-hint {
+  margin-top: 0;
+}
+
+@import 'views/security-forms';
+@import 'views/security-form-fields';

--- a/mtp_noms_ops/assets-src/stylesheets/views/_security-forms.scss
+++ b/mtp_noms_ops/assets-src/stylesheets/views/_security-forms.scss
@@ -17,10 +17,6 @@
     }
   }
 
-  .form-label {
-    font-weight: bold;
-  }
-
   .form-range-field {
     width: 15em;
     margin-top: 1.15789em;
@@ -41,23 +37,26 @@
   padding-bottom: 1em;
   background: $grey-3;
 
-  h3 {
+  h2 {
     margin-top: 1em;
   }
 }
 
 .ResultsList {
-  h3 {
+  h2 {
     margin-top: 0;
   }
 
   table {
     width: 100%;
     margin-bottom: 1.5em;
-    font-size: 0.7em;
 
     thead th {
       border-top: 0;
+    }
+
+    td {
+      font-size: 0.7em;
     }
   }
 }

--- a/mtp_noms_ops/settings/base.py
+++ b/mtp_noms_ops/settings/base.py
@@ -95,6 +95,7 @@ TEMPLATES = [
         'BACKEND': 'django.template.backends.django.DjangoTemplates',
         'DIRS': [
             get_project_dir('templates'),
+            get_project_dir('assets/templates'),
             get_project_dir('node_modules'),
             get_project_dir('../node_modules/mojular-templates'),
         ],

--- a/mtp_noms_ops/templates/base.html
+++ b/mtp_noms_ops/templates/base.html
@@ -7,7 +7,7 @@
   {% sentry_js %}
 {% endblock %}
 
-{% block after_main_js %}
+{% block body_end %}
   {{ block.super }}
   <!-- {% if request.resolver_match.namespace %}{{ request.resolver_match.namespace }}:{% endif %}{{ request.resolver_match.url_name }} -->
 {% endblock %}

--- a/mtp_noms_ops/templates/feedback/submit_feedback.html
+++ b/mtp_noms_ops/templates/feedback/submit_feedback.html
@@ -1,10 +1,10 @@
 {% extends "base.html" %}
 {% load i18n %}
 
-{% block content %}
+{% block inner_content %}
 <header class="ContentHeader">
   <a href="{% url 'location_file_upload' %}" class="ContentHeader-back">{% trans 'Home' %}</a>
-  <h1>{% trans 'Your feedback' %}</h1>
+  <h1 class="heading-xlarge">{% trans 'Your feedback' %}</h1>
 </header>
 
 <form action="." method="post" id="send-feedback">
@@ -23,7 +23,7 @@
       </div>
     {% endwith %}
 
-    <h2>{% trans 'Do you want a reply?' %}</h2>
+    <h2 class="heading-medium">{% trans 'Do you want a reply?' %}</h2>
     <p>{% trans 'Enter your email address if you’d like a reply. We won’t use it for anything else.' %}</p>
 
     {% include 'mtp_common/forms/field.html' with field=form.contact_email only %}

--- a/mtp_noms_ops/templates/prisoner_location_admin/location_file_upload.html
+++ b/mtp_noms_ops/templates/prisoner_location_admin/location_file_upload.html
@@ -1,8 +1,8 @@
 {% extends "base.html" %}
 {% load i18n %}
 
-{% block content %}
-<h1>{% trans 'Upload location file' %}</h1>
+{% block inner_content %}
+<h1 class="heading-xlarge">{% trans 'Upload location file' %}</h1>
 
 {% include 'mtp_common/includes/message_box.html' %}
 
@@ -18,7 +18,7 @@
     {% trans 'Run the “Electronic Credits and Prisoner Establishment Locations” report in P-NOMIS, then upload the file on this page in CSV format (.csv)' %}
   </div>
 
-  <div class="form-group panel-indent panel-border-wide">
+  <div class="panel panel-border-wide">
     {% trans 'Please note that the uploaded prisoner locations will replace all those currently stored in the system.' %}
   </div>
 

--- a/mtp_noms_ops/templates/security/credits.html
+++ b/mtp_noms_ops/templates/security/credits.html
@@ -2,10 +2,10 @@
 {% load i18n %}
 {% load security %}
 
-{% block content %}
+{% block inner_content %}
   <header class="ContentHeader">
     <a href="{% url 'security:dashboard' %}" class="ContentHeader-back">{% trans 'Home' %}</a>
-    <h1>{{ view.title }}</h1>
+    <h1 class="heading-xlarge">{{ view.title }}</h1>
   </header>
 
   {% include 'mtp_common/includes/message_box.html' %}
@@ -17,7 +17,7 @@
 
     <div class="grid-row">
       <aside class="ResultsFormWrapper column-third">
-        <h3>{% trans 'Edit your search' %}</h3>
+        <h2 class="heading-medium">{% trans 'Edit your search' %}</h2>
 
         {% include view.form_template_name with view=view form=form only %}
 
@@ -27,7 +27,7 @@
       </aside>
 
       <div class="ResultsList column-two-thirds">
-        <h3>{% trans 'Results' %}</h3>
+        <h2 class="heading-large">{% trans 'Results' %}</h2>
 
         {% include 'security/select-field.html' with field=form.ordering only %}
 
@@ -79,4 +79,4 @@
 
   </form>
 
-{% endblock content %}
+{% endblock %}

--- a/mtp_noms_ops/templates/security/dashboard.html
+++ b/mtp_noms_ops/templates/security/dashboard.html
@@ -1,7 +1,7 @@
 {% extends 'base.html' %}
 {% load i18n %}
 
-{% block content %}
+{% block inner_content %}
   <p>{% trans 'Home' %}</p>
 
   <ul class="SummaryBoxes">
@@ -27,4 +27,4 @@
     </li>
   </ul>
 
-{% endblock content %}
+{% endblock %}

--- a/mtp_noms_ops/templates/security/grouped-credits.html
+++ b/mtp_noms_ops/templates/security/grouped-credits.html
@@ -2,10 +2,10 @@
 {% load i18n %}
 {% load security %}
 
-{% block content %}
+{% block inner_content %}
   <header class="ContentHeader">
     <a href="{% unserialise_back_url request %}" class="ContentHeader-back ContentHeader-arrow">{% trans 'Back' %}</a>
-    <h1>{% block credit_group_title %}{{ view.title }}{% endblock %}</h1>
+    <h1 class="heading-xlarge">{% block credit_group_title %}{{ view.title }}{% endblock %}</h1>
   </header>
 
   {% include 'mtp_common/includes/message_box.html' %}

--- a/mtp_noms_ops/templates/security/grouped.html
+++ b/mtp_noms_ops/templates/security/grouped.html
@@ -1,10 +1,10 @@
 {% extends 'base.html' %}
 {% load i18n %}
 
-{% block content %}
+{% block inner_content %}
   <header class="ContentHeader">
     <a href="{% url 'security:dashboard' %}" class="ContentHeader-back">{% trans 'Home' %}</a>
-    <h1>{{ view.title }}</h1>
+    <h1 class="heading-xlarge">{{ view.title }}</h1>
   </header>
 
   {% include 'mtp_common/includes/message_box.html' %}
@@ -16,7 +16,7 @@
 
     <div class="grid-row">
       <aside class="ResultsFormWrapper column-third">
-        <h3>{% trans 'Edit your search' %}</h3>
+        <h2 class="heading-medium">{% trans 'Edit your search' %}</h2>
 
         {% include view.form_template_name with view=view form=form only %}
 
@@ -26,7 +26,7 @@
       </aside>
 
       <div class="ResultsList column-two-thirds">
-        <h3>{% trans 'Results' %}</h3>
+        <h2 class="heading-large">{% trans 'Results' %}</h2>
 
         {% include 'security/select-field.html' with field=form.ordering only %}
 
@@ -58,4 +58,4 @@
 
   </form>
 
-{% endblock content %}
+{% endblock %}

--- a/mtp_noms_ops/templates/security/search.html
+++ b/mtp_noms_ops/templates/security/search.html
@@ -1,10 +1,10 @@
 {% extends 'base.html' %}
 {% load i18n %}
 
-{% block content %}
+{% block inner_content %}
   <header class="ContentHeader">
     <a href="{% url 'security:dashboard' %}" class="ContentHeader-back">{% trans 'Home' %}</a>
-    <h1>{{ view.title }}</h1>
+    <h1 class="heading-xlarge">{{ view.title }}</h1>
   </header>
 
   {% include 'mtp_common/includes/message_box.html' %}

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,4 +1,4 @@
 # Place development dependencies here
 -r base.txt
 
-money-to-prisoners-common[testing]==3.19.0
+money-to-prisoners-common[testing]==4.1.0

--- a/requirements/docker.txt
+++ b/requirements/docker.txt
@@ -1,5 +1,5 @@
 # Place docker dependencies here
 -r base.txt
 
-money-to-prisoners-common[monitoring]==3.19.0
+money-to-prisoners-common[monitoring]==4.1.0
 uWSGI==2.0.12

--- a/run.sh
+++ b/run.sh
@@ -38,10 +38,11 @@ COMMAND=$1
 APP=noms_ops
 VIRTUAL_ENV_DIR=venv
 NODE_MODULES=node_modules
+GOVUK_TEMPLATE_VERSION=0.17.3
 
 case "$COMMAND" in
     clean)
-        rm -rf $VIRTUAL_ENV_DIR $NODE_MODULES static mtp_$APP/assets
+        rm -rf $VIRTUAL_ENV_DIR $NODE_MODULES static mtp_$APP/assets mtp_$APP/templates/govuk_template
         ;;
     serve | watch | docker | update | build | test | start)
         PORT=8003
@@ -73,7 +74,7 @@ case "$COMMAND" in
         else
             echo "Common resources found at $PYTHON_LIBS"
         fi
-        echo "Installing front-end assets"
+        echo "Installing npm front-end assets"
         npm install >/dev/null
         npm install `cat $PYTHON_LIBS/mtp_common/npm_requirements.txt` >/dev/null
         mkdir -p $MTP_COMMON_NODE_MODULES

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -4,11 +4,10 @@ var webpack = require('webpack');
 
 module.exports = {
   entry: {
-    app: './mtp_noms_ops/assets-src/javascripts/main.js',
-    polyfills: ['JSON2', 'html5shiv']
+    app: './mtp_noms_ops/assets-src/javascripts/main.js'
   },
   output: {
-    path: './mtp_noms_ops/assets/scripts',
+    path: './mtp_noms_ops/assets/javascripts',
     filename: '[name].bundle.js'
   },
   module: {
@@ -21,8 +20,7 @@ module.exports = {
   },
   resolve: {
     root: [
-      __dirname + '/node_modules',
-      __dirname + '/node_modules/mojular-moj-elements/node_modules'
+      __dirname + '/node_modules'
     ],
     modulesDirectories: [
       './mtp_noms_ops/assets-src/javascripts/modules',


### PR DESCRIPTION
* use latest common
* require js scripts the standard way
* add stylesheets for old ie versions
* align to govuk visual styles,
* use govuk classes, markup and template
* find new govuk-templates
* make endblocks consistent
* adapt run script and webpack config