### PR TITLE
Remove 'restrict_applications' argument to login view

### DIFF
--- a/mtp_noms_ops/apps/prisoner_location_admin/tests/test_views.py
+++ b/mtp_noms_ops/apps/prisoner_location_admin/tests/test_views.py
@@ -3,6 +3,7 @@ from unittest import mock
 
 from django.core.urlresolvers import reverse
 from django.test import SimpleTestCase
+from mtp_common.auth.exceptions import Forbidden
 from mtp_common.auth.test_utils import generate_tokens
 from slumber.exceptions import HttpClientError
 
@@ -55,17 +56,7 @@ class PrisonerLocationAdminViewsTestCase(SimpleTestCase):
 
     @mock.patch('mtp_common.auth.backends.api_client')
     def test_cannot_login_without_app_access(self, mock_api_client):
-        mock_api_client.authenticate.return_value = {
-            'pk': 5,
-            'token': generate_tokens(),
-            'user_data': {
-                'first_name': 'Sam',
-                'last_name': 'Hall',
-                'username': 'shall',
-                'applications': [''],
-                'permissions': required_permissions,
-            }
-        }
+        mock_api_client.authenticate.side_effect = Forbidden
 
         response = self.client.post(
             reverse('login'),

--- a/mtp_noms_ops/urls.py
+++ b/mtp_noms_ops/urls.py
@@ -26,7 +26,6 @@ urlpatterns = [
     url(
         r'^login/$', auth_views.login, {
             'template_name': 'mtp_auth/login.html',
-            'restrict_applications': (settings.API_CLIENT_ID,),
         }, name='login'),
     url(
         r'^logout/$', auth_views.logout, {

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,4 +1,4 @@
 # Place development dependencies here
 -r base.txt
 
-money-to-prisoners-common[testing]==4.7.0
+money-to-prisoners-common[testing]==4.9.0

--- a/requirements/docker.txt
+++ b/requirements/docker.txt
@@ -1,5 +1,5 @@
 # Place docker dependencies here
 -r base.txt
 
-money-to-prisoners-common[monitoring]==4.7.0
+money-to-prisoners-common[monitoring]==4.9.0
 uWSGI==2.0.12


### PR DESCRIPTION
This is no longer needed as application restrictions are checked
in the API.