### PR TITLE
Remove non-ajax version of security searches

### DIFF
--- a/mtp_noms_ops/assets-src/javascripts/modules/security-forms.js
+++ b/mtp_noms_ops/assets-src/javascripts/modules/security-forms.js
@@ -13,9 +13,9 @@ exports.SecurityForms = {
   },
 
   bindAmountPatternSelection: function() {
-    var $patternSelect = $('#id_amount_pattern'),
-      $exactWrapper = $('#id_amount_exact-wrapper'),
-      $penceWrapper = $('#id_amount_pence-wrapper');
+    var $patternSelect = $('#id_amount_pattern');
+    var $exactWrapper = $('#id_amount_exact-wrapper');
+    var $penceWrapper = $('#id_amount_pence-wrapper');
 
     function update() {
       switch ($patternSelect.val()) {
@@ -41,46 +41,43 @@ exports.SecurityForms = {
     var creditRowClass = 'CreditDetailRow';
 
     function creditToggle(e) {
-      var $link = $(e.target);
-      var showTitle = $link.data('show-title');
-      var loadingTitle = $link.data('loading-title');
-      var hideTitle = $link.data('hide-title');
-      var state = $link.data('credit-detail');
+      var $button = $(e.target);
+      var showTitle = $button.data('show-title');
+      var loadingTitle = $button.data('loading-title');
+      var hideTitle = $button.data('hide-title');
+      var state = $button.data('credit-detail');
 
       function loadCreditDetails(html) {
-        var $thisRow = $link.closest('tr').addClass('no-border'),
-          $creditList = $(html).find('.ResultsList'),
-          $creditRow = $('<tr></tr>').addClass(creditRowClass).addClass($thisRow.attr('class')),
-          $creditCell = $('<td></td>'),
-          columns = 0;
+        var $thisRow = $button.closest('tr').addClass('no-border');
+        var $creditRow = $('<tr></tr>').addClass(creditRowClass).addClass($thisRow.attr('class'));
+        var $creditCell = $('<td></td>');
+        var columns = 0;
 
-        $creditList.find('caption').remove();
-        $creditList.find('.CollapsingTable').removeClass('CollapsingTable');
-        $creditList.find('tr th:first-of-type, tr td:first-of-type').each(function() {
-          $(this).remove();
-        });
         $thisRow.find('td').each(function () {
           columns += parseInt($(this).attr('colspan') || '1', 10);
         });
         $creditRow.append(
-          $creditCell.append($creditList).attr('colspan', columns)
+          $creditCell.append($(html)).attr('colspan', columns)
         );
         $thisRow.after($creditRow);
 
-        $link.text(hideTitle);
-        $link.data('credit-detail', 'loaded');
+        $button
+          .text(hideTitle)
+          .data('credit-detail', 'loaded')
+          .attr('aria-expanded', 'true');
       }
 
       function removeCreditDetails() {
-        var $thisRow = $link.closest('tr').removeClass('no-border'),
-          $creditDetailsRow = $thisRow.next();
+        var $thisRow = $button.closest('tr').removeClass('no-border');
+        var $creditDetailsRow = $thisRow.next();
 
         if ($creditDetailsRow.hasClass(creditRowClass)) {
           $creditDetailsRow.remove();
         }
-
-        $link.text(showTitle);
-        $link.data('credit-detail', '');
+        $button
+          .text(showTitle)
+          .data('credit-detail', '')
+          .attr('aria-expanded', 'false');
       }
 
       e.preventDefault();
@@ -91,10 +88,10 @@ exports.SecurityForms = {
       } else if (state !== 'loading') {
         // load credit details
 
-        $link.text(loadingTitle);
-        $link.data('credit-detail', 'loading');
+        $button.text(loadingTitle);
+        $button.data('credit-detail', 'loading');
         $.ajax({
-          url: $link.attr('href'),
+          url: $button.data('fetch'),
           dataType: 'html'
         }).then(
           // load credit details table if ajax works

--- a/mtp_noms_ops/assets-src/stylesheets/views/_security-forms.scss
+++ b/mtp_noms_ops/assets-src/stylesheets/views/_security-forms.scss
@@ -37,16 +37,23 @@
 }
 
 .ResultsList {
-  h2 {
-    margin-top: 0;
-  }
 
   table {
     width: 100%;
     margin-bottom: 1.5em;
 
     th, td {
+      font-size: .85em;
       padding: 0.5em;
+
+      .CreditDetailLink {
+        background-color: $page-colour;
+        font-size: 1em;
+        color: $link-colour;
+        border: none;
+        text-decoration: underline;
+        cursor: pointer;
+      }
     }
   }
 
@@ -58,10 +65,6 @@
       display: block;
     }
   }
-}
-
-.CollapsingTable {
-  font-size: .85em;
 }
 
 .CollapsingTableHeader {
@@ -84,7 +87,7 @@
 
 .CreditDetailRow {
   // credit detail tables that are loaded inline
-
+  font-size: 1.19em;
   table {
     margin-bottom: 0;
     border: 1px solid $border-color;

--- a/mtp_noms_ops/templates/security/grouped-credits.html
+++ b/mtp_noms_ops/templates/security/grouped-credits.html
@@ -1,23 +1,9 @@
-{% extends 'base.html' %}
 {% load i18n %}
 {% load security %}
 
-{% block inner_content %}
-  <header class="ContentHeader">
-    <a href="{% unserialise_back_url request %}" class="ContentHeader-back ContentHeader-arrow">{% trans 'Back' %}</a>
-    <h1 class="heading-xlarge">{% block credit_group_title %}{{ view.title }}{% endblock %}</h1>
-  </header>
-
-  {% include 'mtp_common/includes/message_box.html' %}
-
-  <div class="ResultsList">
-    <table class="CollapsingTable">
-      <caption class="CollapsingTableHeader" data-collapse-text="{% trans 'Collapse' %}" data-expand-text="{% trans 'Expand' %}">
-        {% block group_title %}{% endblock %}
-      </caption>
+    <table>
       <thead>
         <tr>
-          <th>{% trans 'Prisoner' %}</th>
           <th>{% trans 'Prison' %}</th>
           <th title="{% trans 'As specified by sender in reference generator form' %}">
             {% trans 'Intended recipient' %}
@@ -31,12 +17,6 @@
       <tbody>
         {% for credit in credits|parse_date_fields %}
           <tr {% if forloop.last %}class="no-border"{% endif %}>
-            <td>
-              {{ credit.prisoner_name|default_if_none:'—' }}
-              {% if credit.prisoner_number %}
-                (<a href="{% url 'security:credits' %}?page=1&amp;prisoner_number={{ credit.prisoner_number }}">{{ credit.prisoner_number }}</a>)
-              {% endif %}
-            </td>
             <td>{{ credit.prison_name|default_if_none:'—' }}</td>
             <td>{{ credit.intended_recipient|default:'—' }}</td>
             <td>{{ credit.amount|currency }}</td>
@@ -58,7 +38,4 @@
       </tbody>
     </table>
 
-    {% include 'security/pagination.html' %}
-  </div>
 
-{% endblock %}

--- a/mtp_noms_ops/templates/security/prisoner-grouped.html
+++ b/mtp_noms_ops/templates/security/prisoner-grouped.html
@@ -34,13 +34,15 @@
       <td>{{ sender.credit_count }}</td>
       <td>{{ sender.credit_total|currency }}</td>
       <td>
-        <a href="{% get_credits_list_url view form group sender %}&amp;return_to={% serialise_back_url request %}"
+        <button
            class="CreditDetailLink print-hidden"
+           aria-expanded="false"
+           data-fetch="{% get_credits_list_url view form group sender %}"
            data-show-title="{% trans 'Show' %}"
            data-hide-title="{% trans 'Hide' %}"
            data-loading-title="{% trans 'Loading…' %}">
           {% trans 'Show' %}
-        </a>
+        </button>
       </td>
     </tr>
   {% endfor %}

--- a/mtp_noms_ops/templates/security/sender-grouped.html
+++ b/mtp_noms_ops/templates/security/sender-grouped.html
@@ -44,13 +44,15 @@
       <td>{{ prisoner.credit_count }}</td>
       <td>{{ prisoner.credit_total|currency }}</td>
       <td>
-        <a href="{% get_credits_list_url view form group prisoner %}&amp;return_to={% serialise_back_url request %}"
+        <button
            class="CreditDetailLink print-hidden"
+           aria-expanded="false"
+           data-fetch="{% get_credits_list_url view form group prisoner %}"
            data-show-title="{% trans 'Show' %}"
            data-hide-title="{% trans 'Hide' %}"
            data-loading-title="{% trans 'Loading…' %}">
           {% trans 'Show' %}
-        </a>
+        </button>
       </td>
     </tr>
   {% endfor %}


### PR DESCRIPTION
We don't expect no-js users (like cashbook). Therefore
we can simplify the table loaded as well as the corresponding
JS code. Styling is also simplified