### PR TITLE
Update superuser password used on test environments

### DIFF
--- a/mtp_noms_ops/apps/prisoner_location_admin/tests/test_functional.py
+++ b/mtp_noms_ops/apps/prisoner_location_admin/tests/test_functional.py
@@ -46,7 +46,7 @@ class LoginTests(PrisonerLocationAdminTestCase):
         self.assertCurrentUrl(reverse('login'))
 
     def test_superuser_can_see_security_link(self):
-        self.login('admin', 'admin')
+        self.login('admin', 'adminadmin')
         prisoner_location_url = reverse('location_file_upload')
         security_url = reverse('security:dashboard')
         self.assertCurrentUrl(prisoner_location_url)

--- a/mtp_noms_ops/apps/security/tests/test_functional.py
+++ b/mtp_noms_ops/apps/security/tests/test_functional.py
@@ -23,7 +23,7 @@ class SecurityDashboardTests(SecurityDashboardTestCase):
         self.assertEqual(self.driver.title, 'NOMS admin')
 
     def test_superuser_can_see_prisoner_location_link(self):
-        self.login('admin', 'admin')
+        self.login('admin', 'adminadmin')
         prisoner_location_url = reverse('location_file_upload')
         security_url = reverse('security:dashboard')
         self.driver.get(urljoin(self.live_server_url, security_url))


### PR DESCRIPTION
New password rules do not allow for a password of 'admin'.