### PR TITLE
Add tool for certain staff in some prisons to pre-approve credits

### DIFF
--- a/mtp_noms_ops/apps/security/urls.py
+++ b/mtp_noms_ops/apps/security/urls.py
@@ -22,4 +22,6 @@ urlpatterns = [
         name='credits'),
     url(r'^credits/export$', security_test(views.CreditsExportView.as_view()),
         name='credits_export'),
+    url(r'^review-credits/$', security_test(views.ReviewCreditsView.as_view()),
+        name='review_credits'),
 ]

--- a/mtp_noms_ops/assets-src/javascripts/main.js
+++ b/mtp_noms_ops/assets-src/javascripts/main.js
@@ -8,6 +8,7 @@
   require('help-popup').HelpPopup.init();
   require('collapsing-table').CollapsingTable.init();
   require('selection-buttons').SelectionButtons.init();
+  require('print').Print.init();
 
   require('security-forms').SecurityForms.init();
 })();

--- a/mtp_noms_ops/assets-src/stylesheets/app.scss
+++ b/mtp_noms_ops/assets-src/stylesheets/app.scss
@@ -3,6 +3,7 @@
 @import 'mtp';
 @import 'views/security-forms';
 @import 'views/security-form-fields';
+@import 'views/review';
 
 // govuk elements overrides
 

--- a/mtp_noms_ops/assets-src/stylesheets/views/_review.scss
+++ b/mtp_noms_ops/assets-src/stylesheets/views/_review.scss
@@ -1,0 +1,41 @@
+.mtp-review {
+  margin: 0;
+
+  .actions {
+    margin-top: $gutter;
+    margin-bottom: $gutter;
+
+    a {
+      line-height: 175%;
+      margin-left: $gutter;
+    }
+  }
+
+  table {
+    width: 100%;
+    border-top: 1px solid $grey-2;
+    border-bottom: 1px solid $grey-2;
+
+    textarea {
+      width: 100%;
+    }
+
+    tr {
+      td {
+        border-bottom: 0;
+      }
+    }
+
+    .numeric {
+      font-size: 19px;
+    }
+
+    .sender, .prisoner {
+      font-size: 16px;
+
+      .line1 {
+        font-size: 19px;
+      }
+    }
+  }
+}

--- a/mtp_noms_ops/templates/base.html
+++ b/mtp_noms_ops/templates/base.html
@@ -19,8 +19,11 @@
 {% block proposition_menu %}
   {% if request.user.is_authenticated %}
     <ul id="proposition-links" class="print-hidden">
-      {% if request.can_access_security and request.can_access_prisoner_location or request.can_access_user_management %}
+      {% if request.can_access_security and request.can_access_prisoner_location or request.can_access_user_management or request.can_pre_approve %}
         {% if request.can_access_security %}
+          {% if request.can_pre_approve %}
+            <li><a href="{% url 'security:review_credits' %}">{% trans 'New credits check' %}</a></li>
+          {% endif %}
           <li><a href="{% url 'security:dashboard' %}">{% trans 'All prisons’ credit search' %}</a></li>
         {% endif %}
         {% if request.can_access_prisoner_location %}

--- a/mtp_noms_ops/templates/security/credits.html
+++ b/mtp_noms_ops/templates/security/credits.html
@@ -57,7 +57,7 @@
           <tbody>
             {% for credit in credits|parse_date_fields %}
               <tr {% if forloop.last %}class="no-border"{% endif %}>
-                <td>{{ credit.sender_name | default_if_none:'-' }}</td>
+                <td>{{ credit.sender_name | default_if_none:'—' }}</td>
                 <td>
                   {{ credit.prisoner_name|default_if_none:'—' }}
                   {% if credit.prisoner_number %}

--- a/mtp_noms_ops/templates/security/review.html
+++ b/mtp_noms_ops/templates/security/review.html
@@ -1,0 +1,73 @@
+{% extends "base.html" %}
+{% load i18n %}
+{% load security %}
+
+{% block page_title %}{% trans 'New credits check' %}{% endblock %}
+
+{% block inner_content %}
+<h1 class="heading-xlarge">{{ view.title }}</h1>
+
+{% include "mtp_common/includes/message_box.html" %}
+
+<p>
+  {% trans 'Your prison has requested that credits be checked by security before action is taken cashiers.' %}'
+  {% trans 'Please check the following credits and make comments where needed, then select ‘Credits checked by security’.' %}
+  {% trans 'Credits can always be viewed again from ‘Search all prison credits’.' %}
+</p>
+
+<div class="mtp-review">
+  {% if credits %}
+  <form method="post" action="">
+    {% csrf_token %}
+
+    <div class="actions print-hidden">
+      <input type="submit" class="button" value="{% trans 'Credits checked by security' %}"/>
+      <a class="js-Print" href="#print-dialog">{% trans 'Print these credits' %}</a>
+    </div>
+
+    <table>
+      <thead>
+        <tr>
+          <th>{% trans 'Sender' %}</th>
+          <th>{% trans 'Prisoner' %}</th>
+          <th>{% trans 'Amount' %}</th>
+          <th>{% trans 'Security comments' %}</th>
+        </tr>
+      </thead>
+
+      <tbody>
+      {% for credit in credits %}
+        <tr valign="top">
+          <td class="sender">
+            {% if credit.source == 'online' %}
+              <div class="line1">{{ credit.sender_email|default_if_none:'—' }}</div>
+              <div>**** **** **** ****</div>
+              <div>{% trans 'Debit card payment' %}</div>
+            {% else %}
+              <div class="line1">{{ credit.sender_name|default_if_none:'—' }}</div>
+              <div>{{ credit.sender_account_number }} {{ credit.sender_sort_code|format_sort_code }}</div>
+              <div>{% trans 'Bank transfer' %}</div>
+            {% endif %}
+          </td>
+          <td class="prisoner">
+            <div class="line1">{{ credit.prisoner_number }}</div>
+            <div>{{ credit.prisoner_name }}</div>
+          </td>
+          <td class="numeric">&pound;{{ credit.amount|currency }}</td>
+          <td><textarea rows="4" name="comment_{{ credit.id }}"></textarea></td>
+        </tr>
+      {% endfor %}
+      </tbody>
+    </table>
+
+    <div class="actions print-hidden">
+      <input type="submit" class="button" value="{% trans 'Credits checked by security' %}"/>
+    </div>
+  </form>
+</div>
+{% else %}
+{% trans 'No new credits for review.' %}
+{% endif %}
+
+
+{% endblock %}

--- a/mtp_noms_ops/templates/security/review.html
+++ b/mtp_noms_ops/templates/security/review.html
@@ -44,13 +44,13 @@
               <div>**** **** **** ****</div>
               <div>{% trans 'Debit card payment' %}</div>
             {% else %}
-              <div class="line1">{{ credit.sender_name|default_if_none:'—' }}</div>
+              <div class="line1"><a href="{% url 'security:sender_grouped' %}?page=1&sender_name={{ credit.sender_name }}&sender_account_number={{ credit.sender_account_number }}&sender_sort_code={{ credit.sender_sort_code }}">{{ credit.sender_name|default_if_none:'—' }}</a></div>
               <div>{{ credit.sender_account_number }} {{ credit.sender_sort_code|format_sort_code }}</div>
               <div>{% trans 'Bank transfer' %}</div>
             {% endif %}
           </td>
           <td class="prisoner">
-            <div class="line1">{{ credit.prisoner_number }}</div>
+            <div class="line1"><a href="{% url 'security:prisoner_grouped' %}?page=1&prisoner_number={{ credit.prisoner_number }}">{{ credit.prisoner_number }}</a></div>
             <div>{{ credit.prisoner_name }}</div>
           </td>
           <td class="numeric">&pound;{{ credit.amount|currency }}</td>

--- a/mtp_noms_ops/utils.py
+++ b/mtp_noms_ops/utils.py
@@ -14,6 +14,10 @@ class UserPermissionMiddleware:
         request.can_access_prisoner_location = request.user.has_perms(prisoner_location_permissions)
         request.can_access_security = request.user.has_perms(security_permissions)
         request.can_access_user_management = request.user.has_perm('auth.change_user')
+        request.can_pre_approve = any((
+            prison['pre_approval_required']
+            for prison in request.user.user_data.get('prisons', [])
+        ))
 
 
 def external_breadcrumbs(request):


### PR DESCRIPTION
One of the stories that came out of research in the high security
estate was that security staff pre-approve credits before biz hub staff
pay the money to the prisoners. To support this, we have added a
payment review tool to allow security staff to sign off and leave
comments on incoming credits. The review status and comments are then
visible to the biz hub staff.