### PR TITLE
Make print layouts consistent for security filter results

### DIFF
--- a/mtp_noms_ops/assets-src/stylesheets/views/_security-results.scss
+++ b/mtp_noms_ops/assets-src/stylesheets/views/_security-results.scss
@@ -31,7 +31,12 @@
 
   @media print {
     td {
-      padding: 0 5px;
+      padding-top: 2px;
+      padding-bottom: 2px;
+
+      p {
+        margin-bottom: 0;
+      }
     }
 
     p {


### PR DESCRIPTION
So that printed pages for credits, prisoners and senders filtered lists look the same