### PR TITLE
Add warning that not all credits may actually be from the same card

### DIFF
--- a/mtp_noms_ops/apps/security/tests/test_views.py
+++ b/mtp_noms_ops/apps/security/tests/test_views.py
@@ -269,7 +269,7 @@ class SenderListTestCase(SecurityViewTestCase):
         self.assertIn('**** **** **** 1234', response_content)
         self.assertSequenceEqual(response.context['other_cardholder_names'], ['Maisie Nolan'])
         self.assertIn('<strong>Maisie Nolan</strong>', response_content)  # another name used
-        self.assertNotIn('MAISIE N', response_content)  # complete names list is not included
+        self.assertNotIn('<strong>MAISIE N</strong>', response_content)  # complete names list is not included
         self.assertIn('m@outside.local', response_content)
         self.assertNotIn('M@OUTSIDE.LOCAL', response_content)
         self.assertIn('JAMES HALLS', response_content)

--- a/mtp_noms_ops/assets-src/stylesheets/views/_senders-detail.scss
+++ b/mtp_noms_ops/assets-src/stylesheets/views/_senders-detail.scss
@@ -54,3 +54,13 @@
     background-size: 50px 50px;
   }
 }
+
+.mtp-sender-summary__sender-warning {
+  background-color: $orange;
+  color: #ffffff;
+
+  padding: 1em;
+  margin-top: 1em;
+  text-align: center;
+}
+

--- a/mtp_noms_ops/templates/security/senders-detail.html
+++ b/mtp_noms_ops/templates/security/senders-detail.html
@@ -5,6 +5,15 @@
 
 {% block inner_content %}
 
+  {% if sender_emails|length > 1 or other_cardholder_names|length > 1 %}
+  <div class="grid-row mtp-sender-summary__sender-warning">
+    <div class="column-full">
+      {% trans 'We’re currently fixing an issue where senders are being identified only by the last four digits of their card and its expiry date.' %}
+      {% trans 'These credits may not all be from the same sender.' %}
+    </div>
+  </div>
+  {% endif %}
+
   <header>
     {% language_switch %}
     <h1 class="heading-xlarge">
@@ -142,6 +151,7 @@
                 </span>
               </a>
             </th>
+            <th>{% trans 'Sender' %}</th>
             <th class="{{ form|ordering_classes:'prisoner_number' }}">
               <a href="?{{ form|query_string_with_reversed_ordering:'prisoner_number' }}">
                 <span>
@@ -167,6 +177,9 @@
             <tr {% if forloop.last %}class="no-border"{% endif %}>
               <td>
                 <p>{{ credit.received_at|date:'DATE_FORMAT' }}</p>
+              </td>
+              <td>
+                <p>{{ credit.sender_name|default:'—' }}</p>
               </td>
               <td>
                 {% if credit.prisoner_number %}
@@ -202,7 +215,7 @@
             </tr>
           {% empty %}
             <tr class="no-border">
-              <td colspan="5">{% trans 'No matching credits found' %}</td>
+              <td colspan="6">{% trans 'No matching credits found' %}</td>
             </tr>
           {% endfor %}
         </tbody>


### PR DESCRIPTION
As the last 4 digits and expiry date have been found to not be sufficient
to uniquely identify a card, need to inform people of this whilst we
work out how to deal with things.