### PR TITLE
Delay retrieving the prisoner photo until after page load

### DIFF
--- a/mtp_noms_ops/apps/security/urls.py
+++ b/mtp_noms_ops/apps/security/urls.py
@@ -22,6 +22,10 @@ urlpatterns = [
     url(r'^prisoners/(?P<prisoner_id>[0-9]+)/$', security_test(views.PrisonerDetailView.as_view()),
         name='prisoner_detail'),
 
+    url(r'^prisoner_image/(?P<prisoner_number>[A-Za-z0-9]+)/$',
+        security_test(views.prisoner_image_view),
+        name='prisoner_image'),
+
     url(r'^review-credits/$', security_test(views.ReviewCreditsView.as_view()),
         name='review_credits'),
 ]

--- a/mtp_noms_ops/assets-src/stylesheets/views/_prisoners-detail.scss
+++ b/mtp_noms_ops/assets-src/stylesheets/views/_prisoners-detail.scss
@@ -1,7 +1,18 @@
 .mtp-prisoner-image {
   float: left;
   margin-right: 30px;
+  width: 160px;
+  height: 200px;
+  background-image: file-url('placeholder-image.png');
 
+  @include device-pixel-ratio {
+    background-image: file-url('placeholder-image@2x.png');
+  }
+
+  img {
+    width: 160px;
+    height: 200px;
+  }
 }
 
 @include media($max-width: 940px) {

--- a/mtp_noms_ops/templates/security/prisoners-detail.html
+++ b/mtp_noms_ops/templates/security/prisoners-detail.html
@@ -12,13 +12,7 @@
       {% if prisoner %}
         {% if nomis_api_available %}
           <div class="mtp-prisoner-image">
-            {% if photo %}
-              <img src="data:image/jpeg;base64,{{ photo }}" alt="{% trans 'Photo of the prisoner' %}"/>
-            {% else %}
-              <img src="{% static 'images/placeholder-image.png' %}"
-              srcset="{% static 'images/placeholder-image@2x.png' %} 2x"
-              alt="{% trans 'Placeholder image for prisoner photo' %}" />
-            {% endif %}
+              <img src="{% url 'security:prisoner_image' prisoner_number=prisoner.prisoner_number %}" srcset="{% url 'security:prisoner_image' prisoner_number=prisoner.prisoner_number %}?ratio=2x 2x" alt="{% trans 'Photo of the prisoner' %}"/>
           </div>
           {% endif %}
         {{ view.title }}


### PR DESCRIPTION
As retrieving the prisoner photo takes some time, do it asynchronously
with loading the page so that the user is not delayed from viewing the
information.