### PR TITLE
Hide sender profile for unknown senders

### DIFF
--- a/mtp_noms_ops/apps/security/tests/test_views.py
+++ b/mtp_noms_ops/apps/security/tests/test_views.py
@@ -378,6 +378,7 @@ class CreditsListTestCase(SecurityViewTestCase):
                     'prison': 'LEI', 'prison_name': 'HMP LEEDS',
                     'sender_name': None,
                     'sender_sort_code': None, 'sender_account_number': None, 'sender_roll_number': None,
+                    'card_number_last_digits': '4444', 'card_expiry_date': '07/18',
                     'resolution': 'credited',
                     'owner': None, 'owner_name': None,
                     'received_at': '2016-05-25T20:24:00Z', 'credited_at': '2016-05-25T20:27:00Z', 'refunded_at': None,

--- a/mtp_noms_ops/templates/security/credits.html
+++ b/mtp_noms_ops/templates/security/credits.html
@@ -76,17 +76,22 @@
                   <p>{{ credit.received_at|date:'DATE_FORMAT' }}</p>
                 </td>
                 <td>
-                  {% if credit.source == 'online' %}
-                    <p class="mtp-credit__card">
-                      <strong><a href="{{ credit|sender_profile_search_url }}" class="mtp-print-url-hidden">{{ credit.sender_name|default:'—' }}</a></strong><br/>
-                      {% trans 'by debit card' %}
+                  {% with known_sender=credit|credit_sender_identifiable %}
+                    <p class="mtp-credit__{% if credit.source == 'online' %}card{% else %}transfer{% endif %}">
+                      <strong>
+                        {% if known_sender %}
+                          <a href="{{ credit|sender_profile_search_url }}" class="mtp-print-url-hidden">{{ credit.sender_name|default:'—' }}</a>
+                        {% else %}
+                          {% trans 'Sender details not recorded' %}
+                        {% endif %}
+                      </strong><br/>
+                      {% if credit.source == 'online' %}
+                        {% trans 'by debit card' %}
+                      {% else %}
+                        {% trans 'by bank transfer' %}
+                      {% endif %}
                     </p>
-                  {% else %}
-                    <p class="mtp-credit__transfer">
-                      <strong><a href="{{ credit|sender_profile_search_url }}" class="mtp-print-url-hidden">{{ credit.sender_name|default:'—' }}</a></strong><br/>
-                      {% trans 'by bank transfer' %}
-                    </p>
-                  {% endif %}
+                  {% endwith %}
                 </td>
                 <td class="number">
                   <p><strong>{{ credit.amount|currency }}</strong></p>

--- a/mtp_noms_ops/templates/security/prisoners-detail.html
+++ b/mtp_noms_ops/templates/security/prisoners-detail.html
@@ -111,39 +111,53 @@
                 <p>{{ credit.received_at|date:'DATE_FORMAT' }}</p>
               </td>
               <td>
-                {% if credit.source == 'online' %}
-                  <div class="mtp-credit__card">
-                    <strong><a href="{{ credit|sender_profile_search_url }}" class="mtp-print-url-hidden">{{ credit.sender_name | default_if_none:'—' }}</a></strong><br />
-                    {% trans 'by debit card' %}
-                  </div>
-                  <p>—</p>
+                {% with known_sender=credit|credit_sender_identifiable %}
+                  {% if credit.source == 'online' %}
+                    <div class="mtp-credit__card">
+                      <strong>
+                        {% if known_sender %}
+                          <a href="{{ credit|sender_profile_search_url }}" class="mtp-print-url-hidden">{{ credit.sender_name|default:'—' }}</a>
+                        {% else %}
+                          {% trans 'Sender details not recorded' %}
+                        {% endif %}
+                      </strong><br />
+                      {% trans 'by debit card' %}
+                    </div>
+                    <p>—</p>
 
-                  {% random_string as profile_label %}
-                  <div id="mtp-label-{{ profile_label }}" class="mtp-prisoner-label">{% trans 'Card number' %}</div>
-                  <div aria-labelledby="mtp-label-{{ profile_label }}">{{ credit.card_number_last_digits|format_card_number }}</div>
-                {% else %}
-                  <div class="mtp-credit__transfer">
-                    <strong><a href="{{ credit|sender_profile_search_url }}" class="mtp-print-url-hidden">{{ credit.sender_name | default_if_none:'—' }}</a></strong><br />
-                    {% trans 'by bank transfer' %}
-                  </div>
-                  <p>—</p>
-
-                  {% random_string as profile_label %}
-                  <div id="mtp-label-{{ profile_label }}" class="mtp-prisoner-label">{% trans 'Account number' %}</div>
-                  <div aria-labelledby="mtp-label-{{ profile_label }}">{{ credit.sender_account_number }}</div>
-                  <br/>
-
-                  {% random_string as profile_label %}
-                  <div id="mtp-label-{{ profile_label }}" class="mtp-prisoner-label">{% trans 'Sort code' %}</div>
-                  <div aria-labelledby="mtp-label-{{ profile_label }}">{{ credit.sender_sort_code|format_sort_code }}</div>
-
-                  {% if credit.sender_roll_number %}
-                    <br/>
                     {% random_string as profile_label %}
-                    <div id="mtp-label-{{ profile_label }}" class="mtp-prisoner-label">{% trans 'Roll number (for building societies)' %}</div>
-                    <div aria-labelledby="mtp-label-{{ profile_label }}">{{ credit.sender_roll_number }}</div>
+                    <div id="mtp-label-{{ profile_label }}" class="mtp-prisoner-label">{% trans 'Card number' %}</div>
+                    <div aria-labelledby="mtp-label-{{ profile_label }}">{{ credit.card_number_last_digits|format_card_number }}</div>
+                  {% else %}
+                    <div class="mtp-credit__transfer">
+                      <strong>
+                        {% if known_sender %}
+                          <a href="{{ credit|sender_profile_search_url }}" class="mtp-print-url-hidden">{{ credit.sender_name|default:'—' }}</a>
+                        {% else %}
+                          {% trans 'Sender details not recorded' %}
+                        {% endif %}
+                      </strong><br />
+                      {% trans 'by bank transfer' %}
+                    </div>
+                    <p>—</p>
+
+                    {% random_string as profile_label %}
+                    <div id="mtp-label-{{ profile_label }}" class="mtp-prisoner-label">{% trans 'Account number' %}</div>
+                    <div aria-labelledby="mtp-label-{{ profile_label }}">{{ credit.sender_account_number }}</div>
+                    <br/>
+
+                    {% random_string as profile_label %}
+                    <div id="mtp-label-{{ profile_label }}" class="mtp-prisoner-label">{% trans 'Sort code' %}</div>
+                    <div aria-labelledby="mtp-label-{{ profile_label }}">{{ credit.sender_sort_code|format_sort_code }}</div>
+
+                    {% if credit.sender_roll_number %}
+                      <br/>
+                      {% random_string as profile_label %}
+                      <div id="mtp-label-{{ profile_label }}" class="mtp-prisoner-label">{% trans 'Roll number (for building societies)' %}</div>
+                      <div aria-labelledby="mtp-label-{{ profile_label }}">{{ credit.sender_roll_number }}</div>
+                    {% endif %}
                   {% endif %}
-                {% endif %}
+                {% endwith %}
               </td>
               <td>
                 {{ credit.intended_recipient|default_if_none:'—' }}

--- a/mtp_noms_ops/templates/security/review.html
+++ b/mtp_noms_ops/templates/security/review.html
@@ -44,7 +44,15 @@
         {% for credit in credits %}
           <tr>
             <td class="mtp-review__sender">
-              <div class="line1"><a class="mtp-print-url-hidden" href="{{ credit|sender_profile_search_url }}">{{ credit.sender_name|default_if_none:'—' }}</a></div>
+              <div class="line1">
+                {% with known_sender=credit|credit_sender_identifiable %}
+                  {% if known_sender %}
+                    <a class="mtp-print-url-hidden" href="{{ credit|sender_profile_search_url }}">{{ credit.sender_name|default_if_none:'—' }}</a>
+                  {% else %}
+                    {% trans 'Sender details not recorded' %}
+                  {% endif %}
+                {% endwith %}
+              </div>
               {% if credit.source == 'online' %}
                 {{ credit.sender_email|default_if_none:'—' }}<br/>
                 {{ credit.card_number_last_digits|format_card_number }} {{ credit.card_expiry_date|default_if_none:'' }}<br/>

--- a/mtp_noms_ops/templates/security/senders.html
+++ b/mtp_noms_ops/templates/security/senders.html
@@ -73,49 +73,53 @@
           </thead>
           <tbody>
             {% for sender in senders %}
-              <tr {% if forloop.last %}class="no-border"{% endif %}>
-                <td>
-                  {% if sender.bank_transfer_details %}
-                  <p class="mtp-credit__transfer">
-                    <a href="{% url 'security:sender_detail' sender.id %}" class="mtp-print-url-hidden">
-                      <strong>{{ sender.bank_transfer_details.0.sender_name|default:'—' }}</strong>
-                    </a><br />
-                    {% trans 'by bank transfer' %}
-                  </p>
-                  {% elif sender.debit_card_details %}
-                  <p class="mtp-credit__card">
-                    <a href="{% url 'security:sender_detail' sender.id %}" class="mtp-print-url-hidden">
-                      <strong>{{ sender.debit_card_details.0.cardholder_names.0|default:'—' }}</strong>
-                    </a><br />
-                    {% trans 'by debit card' %}
-                  </p>
-                  {% else %}
-                    —
-                  {% endif %}
-                </td>
-                <td>
-                  {% blocktrans trimmed count count=sender.credit_count %}
-                    <strong>{{ count }}</strong> credit sent
-                  {% plural %}
-                    <strong>{{ count }}</strong> credits sent
-                  {% endblocktrans %}
-                </td>
-                <td>
-                  {% blocktrans trimmed count count=sender.prisoner_count %}
-                    <strong>{{ count }}</strong> prisoner
-                  {% plural %}
-                    <strong>{{ count }}</strong> prisoners
-                  {% endblocktrans %}
-                </td>
-                <td>
-                  {% blocktrans trimmed count count=sender.prison_count %}
-                    <strong>{{ count }}</strong> prison
-                  {% plural %}
-                    <strong>{{ count }}</strong> prisons
-                  {% endblocktrans %}
-                </td>
-                <td class="number"><strong>{{ sender.credit_total|currency }}</strong></td>
-              </tr>
+              {% with known_sender=sender|sender_identifiable %}
+                {% if known_sender %}
+                  <tr {% if forloop.last %}class="no-border"{% endif %}>
+                    <td>
+                      {% if sender.bank_transfer_details %}
+                      <p class="mtp-credit__transfer">
+                        <a href="{% url 'security:sender_detail' sender.id %}" class="mtp-print-url-hidden">
+                          <strong>{{ sender.bank_transfer_details.0.sender_name|default:'—' }}</strong>
+                        </a><br />
+                        {% trans 'by bank transfer' %}
+                      </p>
+                      {% elif sender.debit_card_details %}
+                      <p class="mtp-credit__card">
+                        <a href="{% url 'security:sender_detail' sender.id %}" class="mtp-print-url-hidden">
+                          <strong>{{ sender.debit_card_details.0.cardholder_names.0|default:'—' }}</strong>
+                        </a><br />
+                        {% trans 'by debit card' %}
+                      </p>
+                      {% else %}
+                        —
+                      {% endif %}
+                    </td>
+                    <td>
+                      {% blocktrans trimmed count count=sender.credit_count %}
+                        <strong>{{ count }}</strong> credit sent
+                      {% plural %}
+                        <strong>{{ count }}</strong> credits sent
+                      {% endblocktrans %}
+                    </td>
+                    <td>
+                      {% blocktrans trimmed count count=sender.prisoner_count %}
+                        <strong>{{ count }}</strong> prisoner
+                      {% plural %}
+                        <strong>{{ count }}</strong> prisoners
+                      {% endblocktrans %}
+                    </td>
+                    <td>
+                      {% blocktrans trimmed count count=sender.prison_count %}
+                        <strong>{{ count }}</strong> prison
+                      {% plural %}
+                        <strong>{{ count }}</strong> prisons
+                      {% endblocktrans %}
+                    </td>
+                    <td class="number"><strong>{{ sender.credit_total|currency }}</strong></td>
+                  </tr>
+                {% endif %}
+              {% endwith %}
             {% empty %}
               <tr class="no-border">
                 <td colspan="5">{% trans 'No matching payment sources found' %}</td>


### PR DESCRIPTION
Credits with unknown senders are aggregated into one 'unknown sender'
profile which is misleading. This sender profile should not show
in the list of senders, nor should it be linked to from other pages.