### PR TITLE
Add notifications for communication with noms ops users

### DIFF
--- a/mtp_noms_ops/assets-src/javascripts/main.js
+++ b/mtp_noms_ops/assets-src/javascripts/main.js
@@ -13,6 +13,7 @@
     ['hmps.gsi.gov.uk', 'noms.gsi.gov.uk', 'justice.gsi.gov.uk'],
     ['gsi.gov.uk', 'gov.uk']
   );
+  require('notifications').Notifications.init();
 
   require('confirm-checked').ConfirmChecked.init();
   require('security-forms').SecurityForms.init();

--- a/mtp_noms_ops/templates/dashboard.html
+++ b/mtp_noms_ops/templates/dashboard.html
@@ -3,6 +3,8 @@
 {% load mtp_common %}
 
 {% block inner_content %}
+  {% notifications_box request 'noms_ops_security_dashboard' %}
+
   <header>
     <h1 class="heading-xlarge mtp-unpadded-heading">
       {% blocktrans trimmed with full_name=request.user.get_full_name|default:request.user.username %}

--- a/mtp_noms_ops/templates/mtp_auth/login.html
+++ b/mtp_noms_ops/templates/mtp_auth/login.html
@@ -40,6 +40,9 @@
   </div>
 
   <div class="mtp-login__content">
+
+    {% notifications_box request 'noms_ops_login' %}
+
     <div class="grid-row">
       <section class="column-half">
         <h2 class="heading-medium">{% trans 'How to get access' %}</h2>


### PR DESCRIPTION
Notifications can be set on the API and will display to users.