### PR TITLE
Update compatibility with latest version of mtp-common

### DIFF
--- a/mtp_noms_ops/apps/security/templatetags/security.py
+++ b/mtp_noms_ops/apps/security/templatetags/security.py
@@ -2,8 +2,7 @@ import logging
 
 from django import template
 from django.core.urlresolvers import reverse
-from django.utils.crypto import get_random_string
-from django.utils.html import escape, format_html
+from django.utils.html import escape
 from django.utils.http import urlencode
 from django.utils.safestring import mark_safe
 from django.utils.translation import gettext
@@ -191,17 +190,3 @@ def find_rejection_reason(comment_set):
     for comment in filter(lambda comment: comment['category'] == 'reject', comment_set):
         return comment['comment']
     return ''
-
-
-@register.simple_tag
-def labelled_data(label, value, tag='div', url=None):
-    element_id = get_random_string(length=4)
-    if url:
-        value = format_html('<a href="{url}">{value}</a>', value=value, url=url)
-    return format_html(
-        '''
-        <div id="mtp-label-{element_id}" class="mtp-detail-label">{label}</div>
-        <{tag} aria-labelledby="mtp-label-{element_id}">{value}</{tag}>
-        ''',
-        element_id=element_id, label=label, value=value, tag=tag
-    )

--- a/mtp_noms_ops/assets-src/stylesheets/views/_security-results.scss
+++ b/mtp_noms_ops/assets-src/stylesheets/views/_security-results.scss
@@ -74,11 +74,6 @@
   }
 }
 
-.mtp-detail-label {
-  color: $secondary-text-colour;
-  font-size: 16px;
-}
-
 .mtp-credit-arrow, .mtp-disbursement-arrow {
   display: inline-block;
   min-width: 33px;

--- a/mtp_noms_ops/templates/mtp_auth/login.html
+++ b/mtp_noms_ops/templates/mtp_auth/login.html
@@ -47,7 +47,7 @@
       <section class="column-half">
         <h2 class="heading-medium">{% trans 'How to get access' %}</h2>
         <p>
-          {% trans 'Your business hub administrator can set up an account for you if you don’t have access already.' %}
+          {% trans 'Your head of security can set up an account for you if you don’t have access already.' %}
         </p>
         <p>
           <a href="{% url 'submit_ticket' %}">

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,4 +1,4 @@
 # Place development dependencies here
 -r base.txt
 
-money-to-prisoners-common[testing]>=7.9,<7.10
+money-to-prisoners-common[testing]>=8.0,<8.1

--- a/requirements/docker.txt
+++ b/requirements/docker.txt
@@ -1,6 +1,6 @@
 # Place docker dependencies here
 -r base.txt
 
-money-to-prisoners-common[monitoring]>=7.9,<7.10
+money-to-prisoners-common[monitoring]>=8.0,<8.1
 
 uWSGI==2.0.17


### PR DESCRIPTION
• disconnects user management overlap between noms-ops and cashbook
• does NOT yet allow sign-up, choosing/switching prison/region, managing requests (more mtp-api changes required first)