### PR TITLE
Ensure compatibility with restructuring of totals on profiles

### DIFF
--- a/mtp_noms_ops/apps/security/forms/object_list.py
+++ b/mtp_noms_ops/apps/security/forms/object_list.py
@@ -10,7 +10,8 @@ from security.forms.object_base import (
     SecurityForm,
     AmountPattern, parse_amount,
     validate_amount, validate_prisoner_number, validate_range_field,
-    insert_blank_option, get_credit_source_choices, get_disbursement_method_choices,
+    insert_blank_option, get_credit_source_choices,
+    get_disbursement_method_choices, TIME_PERIOD_CHOICES
 )
 from security.templatetags.security import currency as format_currency
 from security.utils import parse_date_fields
@@ -32,6 +33,13 @@ class SendersForm(SecurityForm):
                                      ('credit_total', _('Total sent (low to high)')),
                                      ('-credit_total', _('Total sent (high to low)')),
                                  ])
+
+    time_period = forms.ChoiceField(
+        label=_('Time period'),
+        choices=TIME_PERIOD_CHOICES,
+        initial=TIME_PERIOD_CHOICES[0][0],
+        required=False
+    )
 
     prisoner_count__gte = forms.IntegerField(label=_('Number of prisoners (minimum)'), required=False, min_value=1)
     prisoner_count__lte = forms.IntegerField(label=_('Maximum prisoners sent to'), required=False, min_value=1)
@@ -161,6 +169,13 @@ class PrisonersForm(SecurityForm):
                                      ('prisoner_number', _('Prisoner number (A to Z)')),
                                      ('-prisoner_number', _('Prisoner number (Z to A)')),
                                  ])
+
+    time_period = forms.ChoiceField(
+        label=_('Time period'),
+        choices=TIME_PERIOD_CHOICES,
+        initial=TIME_PERIOD_CHOICES[0][0],
+        required=False
+    )
 
     sender_count__gte = forms.IntegerField(label=_('Number of senders (minimum)'), required=False, min_value=1)
     sender_count__lte = forms.IntegerField(label=_('Maximum senders received from'), required=False, min_value=1)

--- a/mtp_noms_ops/urls.py
+++ b/mtp_noms_ops/urls.py
@@ -30,6 +30,8 @@ def root_view(request):
     return redirect(reverse('security:dashboard'))
 
 
+# NB: API settings has certain Noms Ops URLs which will need to be updated
+# if they change: settings, feedback, and notifications
 urlpatterns = i18n_patterns(
     url(r'^$', root_view, name='root'),
     url(r'^prisoner-location/', include('prisoner_location_admin.urls')),


### PR DESCRIPTION
On the API, the totals are now divided by time period, so the client
needs to allow for the selection of time period, have a default
time period to fall back to, and populate the totals of the
returned object according to the selected time period.