### PR TITLE
Create Google analytics events for the search parameters used

### DIFF
--- a/mtp_noms_ops/assets-src/javascripts/main.js
+++ b/mtp_noms_ops/assets-src/javascripts/main.js
@@ -19,4 +19,5 @@
 
   require('confirm-checked').ConfirmChecked.init();
   require('security-forms').SecurityForms.init();
+  require('form-analytics').FormAnalytics.init();
 }());

--- a/mtp_noms_ops/assets-src/javascripts/modules/form-analytics.js
+++ b/mtp_noms_ops/assets-src/javascripts/modules/form-analytics.js
@@ -1,0 +1,37 @@
+'use strict';
+
+var analytics = require('analytics');
+
+exports.FormAnalytics = {
+  selector: '.js-FormAnalytics',
+
+  init: function () {
+    this.cacheEls();
+    this.bindEvents();
+  },
+
+  cacheEls: function () {
+    this.$form = $(this.selector);
+  },
+
+  bindEvents: function () {
+    this.$form.on('submit', $.proxy(this.onSubmit, this));
+  },
+
+  onSubmit: function (e) {
+    var inputs = this.$form.serializeArray();
+    var formId = this.$form.attr('id')
+
+    $.each(inputs, function() {
+      if (this.value) {
+        analytics.Analytics.send(
+          'event', {
+            eventCategory: 'SecurityForms',
+            eventAction: formId,
+            eventLabel: this.name
+          }
+        );
+      }
+    });
+  }
+};

--- a/mtp_noms_ops/templates/security/credits.html
+++ b/mtp_noms_ops/templates/security/credits.html
@@ -13,7 +13,7 @@
 
   {% include 'mtp_common/includes/message_box.html' %}
 
-  <form class="mtp-security-search" method="get">
+  <form id="filter-credits" class="mtp-security-search js-FormAnalytics" method="get">
     {% include 'mtp_common/forms/error-summary.html' with form=form only %}
 
     <p class="lede">{{ form.search_description.description }}</p>
@@ -25,7 +25,7 @@
     {% if form.is_valid %}
       <div class="mtp-results-list">
         <div class="print-hidden mtp-links--no-panel">
-          <a class="js-print-trigger" href="#print-dialog">{% trans 'Print' %}</a>
+          <a class="js-print-trigger" data-analytics="event,SecurityForms,print-{{ view.title }},{{ request.GET.urlencode }}" href="#print-dialog">{% trans 'Print' %}</a>
           &nbsp;
           {% url 'security:credits_export' as export_view %}
           {% url 'security:credits_email_export' as email_export_view %}

--- a/mtp_noms_ops/templates/security/disbursements.html
+++ b/mtp_noms_ops/templates/security/disbursements.html
@@ -13,7 +13,7 @@
 
   {% include 'mtp_common/includes/message_box.html' %}
 
-  <form class="mtp-security-search" method="get">
+  <form id="filter-disbursements" class="mtp-security-search js-FormAnalytics" method="get">
     {% include 'mtp_common/forms/error-summary.html' with form=form only %}
 
     <p class="lede">
@@ -28,7 +28,7 @@
     {% if form.is_valid %}
       <div class="mtp-results-list">
         <div class="print-hidden mtp-links--no-panel">
-          <a class="js-print-trigger" href="#print-dialog">{% trans 'Print' %}</a>
+          <a class="js-print-trigger" data-analytics="event,SecurityForms,print-{{ view.title }},{{ request.GET.urlencode }}" href="#print-dialog">{% trans 'Print' %}</a>
           &nbsp;
           {% url 'security:disbursements_export' as export_view %}
           {% url 'security:disbursements_email_export' as email_export_view %}

--- a/mtp_noms_ops/templates/security/includes/export-dialogue.html
+++ b/mtp_noms_ops/templates/security/includes/export-dialogue.html
@@ -3,7 +3,7 @@
 
 {% if form.total_count <= view.export_download_limit %}
 
-  <a href="{{ export_view }}?{{ request.GET.urlencode }}">{% trans 'Export' %}</a>
+  <a data-analytics="event,SecurityForms,export-{{ view.title }},{{ request.GET.urlencode }}" href="{{ export_view }}?{{ request.GET.urlencode }}">{% trans 'Export' %}</a>
 
 {% elif form.total_count <= view.export_email_limit %}
 

--- a/mtp_noms_ops/templates/security/prisoners.html
+++ b/mtp_noms_ops/templates/security/prisoners.html
@@ -13,7 +13,7 @@
 
   {% include 'mtp_common/includes/message_box.html' %}
 
-  <form class="mtp-security-search" method="get">
+  <form id="filter-prisoners" class="mtp-security-search js-FormAnalytics" method="get">
     {% include 'mtp_common/forms/error-summary.html' with form=form only %}
 
     <p class="lede">{{ form.search_description.description }}</p>
@@ -25,7 +25,7 @@
     {% if form.is_valid %}
       <div class="mtp-results-list">
         <div class="print-hidden mtp-links--no-panel">
-          <a class="js-print-trigger" href="#print-dialog">{% trans 'Print' %}</a>
+          <a class="js-print-trigger" data-analytics="event,SecurityForms,print-{{ view.title }},{{ request.GET.urlencode }}" href="#print-dialog">{% trans 'Print' %}</a>
           &nbsp;
           {% url 'security:prisoners_export' as export_view %}
           {% url 'security:prisoners_email_export' as email_export_view %}

--- a/mtp_noms_ops/templates/security/senders.html
+++ b/mtp_noms_ops/templates/security/senders.html
@@ -13,7 +13,7 @@
 
   {% include 'mtp_common/includes/message_box.html' %}
 
-  <form class="mtp-security-search" method="get">
+  <form id="filter-senders" class="mtp-security-search js-FormAnalytics" method="get">
     {% include 'mtp_common/forms/error-summary.html' with form=form only %}
 
     <p class="lede">{{ form.search_description.description }}</p>
@@ -25,7 +25,7 @@
     {% if form.is_valid %}
       <div class="mtp-results-list">
         <div class="print-hidden mtp-links--no-panel">
-          <a class="js-print-trigger" href="#print-dialog">{% trans 'Print' %}</a>
+          <a class="js-print-trigger" data-analytics="event,SecurityForms,print-{{ view.title }},{{ request.GET.urlencode }}" href="#print-dialog">{% trans 'Print' %}</a>
           &nbsp;
           {% url 'security:senders_export' as export_view %}
           {% url 'security:senders_email_export' as email_export_view %}


### PR DESCRIPTION
This is to allow us to track what filters are used by users, as well
as when they try and export or print data.