### PR TITLE
Fix export event tag on detail pages

### DIFF
--- a/mtp_noms_ops/apps/security/views/object_base.py
+++ b/mtp_noms_ops/apps/security/views/object_base.py
@@ -143,6 +143,9 @@ class SecurityView(FormView):
     def get_export_description(self, form):
         return str(form.search_description['description'])
 
+    def get_class_name(self):
+        return self.__class__.__name__
+
     get = FormView.post
 
 

--- a/mtp_noms_ops/templates/security/credits.html
+++ b/mtp_noms_ops/templates/security/credits.html
@@ -25,7 +25,7 @@
     {% if form.is_valid %}
       <div class="mtp-results-list">
         <div class="print-hidden mtp-links--no-panel">
-          <a class="js-print-trigger" data-analytics="event,SecurityForms,print-{{ view.title }},{{ request.GET.urlencode }}" href="#print-dialog">{% trans 'Print' %}</a>
+          <a class="js-print-trigger" data-analytics="event,SecurityForms,print-{{ view.get_class_name }},{{ request.GET.urlencode }}" href="#print-dialog">{% trans 'Print' %}</a>
           &nbsp;
           {% url 'security:credits_export' as export_view %}
           {% url 'security:credits_email_export' as email_export_view %}

--- a/mtp_noms_ops/templates/security/disbursements.html
+++ b/mtp_noms_ops/templates/security/disbursements.html
@@ -28,7 +28,7 @@
     {% if form.is_valid %}
       <div class="mtp-results-list">
         <div class="print-hidden mtp-links--no-panel">
-          <a class="js-print-trigger" data-analytics="event,SecurityForms,print-{{ view.title }},{{ request.GET.urlencode }}" href="#print-dialog">{% trans 'Print' %}</a>
+          <a class="js-print-trigger" data-analytics="event,SecurityForms,print-{{ view.get_class_name }},{{ request.GET.urlencode }}" href="#print-dialog">{% trans 'Print' %}</a>
           &nbsp;
           {% url 'security:disbursements_export' as export_view %}
           {% url 'security:disbursements_email_export' as email_export_view %}

--- a/mtp_noms_ops/templates/security/includes/export-dialogue.html
+++ b/mtp_noms_ops/templates/security/includes/export-dialogue.html
@@ -3,7 +3,7 @@
 
 {% if form.total_count <= view.export_download_limit %}
 
-  <a data-analytics="event,SecurityForms,export-{{ view.title }},{{ request.GET.urlencode }}" href="{{ export_view }}?{{ request.GET.urlencode }}">{% trans 'Export' %}</a>
+  <a data-analytics="event,SecurityForms,export-{{ view.get_class_name }},{{ request.GET.urlencode }}" href="{{ export_view }}?{{ request.GET.urlencode }}">{% trans 'Export' %}</a>
 
 {% elif form.total_count <= view.export_email_limit %}
 

--- a/mtp_noms_ops/templates/security/prisoners.html
+++ b/mtp_noms_ops/templates/security/prisoners.html
@@ -25,7 +25,7 @@
     {% if form.is_valid %}
       <div class="mtp-results-list">
         <div class="print-hidden mtp-links--no-panel">
-          <a class="js-print-trigger" data-analytics="event,SecurityForms,print-{{ view.title }},{{ request.GET.urlencode }}" href="#print-dialog">{% trans 'Print' %}</a>
+          <a class="js-print-trigger" data-analytics="event,SecurityForms,print-{{ view.get_class_name }},{{ request.GET.urlencode }}" href="#print-dialog">{% trans 'Print' %}</a>
           &nbsp;
           {% url 'security:prisoners_export' as export_view %}
           {% url 'security:prisoners_email_export' as email_export_view %}

--- a/mtp_noms_ops/templates/security/senders.html
+++ b/mtp_noms_ops/templates/security/senders.html
@@ -25,7 +25,7 @@
     {% if form.is_valid %}
       <div class="mtp-results-list">
         <div class="print-hidden mtp-links--no-panel">
-          <a class="js-print-trigger" data-analytics="event,SecurityForms,print-{{ view.title }},{{ request.GET.urlencode }}" href="#print-dialog">{% trans 'Print' %}</a>
+          <a class="js-print-trigger" data-analytics="event,SecurityForms,print-{{ view.get_class_name }},{{ request.GET.urlencode }}" href="#print-dialog">{% trans 'Print' %}</a>
           &nbsp;
           {% url 'security:senders_export' as export_view %}
           {% url 'security:senders_email_export' as email_export_view %}


### PR DESCRIPTION
This changes the event action to be that of the general page title
rather than the specific record being looked at.