### PR TITLE
Avoid filtering by invalid default prison on disbursements page

### DIFF
--- a/mtp_noms_ops/apps/security/utils.py
+++ b/mtp_noms_ops/apps/security/utils.py
@@ -123,6 +123,17 @@ def initial_params(request):
     ], doseq=True)}
 
 
+def initial_disbursement_params(request):
+    if not request.user_prisons:
+        return {}
+    return {'initial_disbursement_params': urlencode([
+        ('prison', prison['nomis_id'])
+        for prison in request.user_prisons
+        if not settings.DISBURSEMENT_PRISONS or
+        prison['nomis_id'] in settings.DISBURSEMENT_PRISONS
+    ], doseq=True)}
+
+
 def nomis_api_available(_):
     return {'nomis_api_available': (
         settings.NOMIS_API_BASE_URL and settings.NOMIS_API_CLIENT_TOKEN and settings.NOMIS_API_PRIVATE_KEY

--- a/mtp_noms_ops/settings/base.py
+++ b/mtp_noms_ops/settings/base.py
@@ -125,6 +125,7 @@ TEMPLATES = [
                 'mtp_noms_ops.utils.govuk_localisation',
                 'mtp_noms_ops.utils.external_breadcrumbs',
                 'mtp_noms_ops.apps.security.utils.initial_params',
+                'mtp_noms_ops.apps.security.utils.initial_disbursement_params',
                 'mtp_noms_ops.apps.security.utils.nomis_api_available',
             ],
         },

--- a/mtp_noms_ops/templates/base.html
+++ b/mtp_noms_ops/templates/base.html
@@ -24,7 +24,7 @@
           {% include 'proposition-tab.html' with view_name='security:credit_list' subview_names='security:credit_list security:credit_detail' link_text=_('Credits') params=initial_params %}
           {% include 'proposition-tab.html' with view_name='security:sender_list' subview_names='security:sender_list security:sender_detail' link_text=_('Payment sources') params=initial_params hide_on_mobile=True %}
           {% include 'proposition-tab.html' with view_name='security:prisoner_list' subview_names='security:prisoner_list security:prisoner_detail security:prisoner_disbursement_detail' link_text=_('Prisoners') params=initial_params hide_on_mobile=True %}
-          {% include 'proposition-tab.html' with view_name='security:disbursement_list' subview_names='security:disbursement_list security:disbursement_detail' link_text=_('Disbursements') params=initial_params %}
+          {% include 'proposition-tab.html' with view_name='security:disbursement_list' subview_names='security:disbursement_list security:disbursement_detail' link_text=_('Disbursements') params=initial_disbursement_params %}
         {% elif request.user.is_authenticated and request.can_access_prisoner_location %}
           {% include 'proposition-tab.html' with view_name='location_file_upload' subview_names='location_file_upload' link_text=_('Upload location file') %}
         {% else %}

--- a/mtp_noms_ops/templates/dashboard.html
+++ b/mtp_noms_ops/templates/dashboard.html
@@ -74,7 +74,7 @@
 
     <div class="grid-row">
       <div class="column-one-third mtp-box">
-        <a href="{% url 'security:disbursement_list' %}?{{ initial_params }}">
+        <a href="{% url 'security:disbursement_list' %}?{{ initial_disbursement_params }}">
           {% trans 'Disbursements' %}
         </a>
       </div>


### PR DESCRIPTION
If a user with a default prison that is not a disbursement prison
goes to the disbursements page, the page will default to not filtering
by any prison.