### PR TITLE
Change GA event sending to be compatible with blanket param stripping

### DIFF
--- a/mtp_noms_ops/assets-src/javascripts/modules/choose-prisons.js
+++ b/mtp_noms_ops/assets-src/javascripts/modules/choose-prisons.js
@@ -22,11 +22,7 @@ exports.ChoosePrisons = {
       currentPrisons = this.addedPrisons($hiddenInputs);
     }
     analytics.Analytics.send(
-      'event', {
-        eventCategory: 'PrisonConfirmation',
-        eventAction: 'Change',
-        eventLabel: currentPrisons
-      }
+      'event', 'PrisonConfirmation', 'Change', currentPrisons
     );
 
     $form.find('input[type=text]').keydown(function(e) {
@@ -70,11 +66,10 @@ exports.ChoosePrisons = {
             );
 
             analytics.Analytics.send(
-              'event', {
-                eventCategory: 'security.forms.preferences.ChoosePrisonForm',
-                eventAction: 'new_prison',
-                eventLabel: emptyErrorMsg
-              }
+              'event',
+              'security.forms.preferences.ChoosePrisonForm',
+              'new_prison',
+              emptyErrorMsg
             );
           }
           noSelection = true;
@@ -93,11 +88,7 @@ exports.ChoosePrisons = {
         addedPrisons = self.addedPrisons($hiddenInputs);
       }
       analytics.Analytics.send(
-        'event', {
-          eventCategory: 'PrisonConfirmation',
-          eventAction: 'Save',
-          eventLabel: addedPrisons
-        }
+        'event', 'PrisonConfirmation', 'Save', addedPrisons
       );
       return true;
     });
@@ -126,11 +117,7 @@ exports.ChoosePrisons = {
 
       var event_label = $confirmButton.data('current-prisons') + ' > ' + newPrisonsStr;
       analytics.Analytics.send(
-        'event', {
-          eventCategory: 'PrisonConfirmation',
-          eventAction: 'Confirm',
-          eventLabel: event_label
-        }
+        'event', 'PrisonConfirmation', 'Confirm', event_label
       );
     });
   }

--- a/mtp_noms_ops/assets-src/javascripts/modules/form-analytics.js
+++ b/mtp_noms_ops/assets-src/javascripts/modules/form-analytics.js
@@ -10,20 +10,10 @@ exports.FormAnalytics = {
   bindForm: function () {
     var $form = $(this);
     var formId = $form.attr('id');
-    var location = $form.data('ga-location');
-    var page = $form.data('ga-page');
-    var title = $form.data('ga-title');
 
     function sendEvent (action, label) {
       analytics.Analytics.send(
-        'event', {
-          eventCategory: 'SecurityForms',
-          eventAction: action,
-          eventLabel: label,
-          location: location,
-          page: page,
-          title: title
-        }
+        'event', 'SecurityForms', action, label
       );
     }
 

--- a/mtp_noms_ops/settings/base.py
+++ b/mtp_noms_ops/settings/base.py
@@ -60,7 +60,7 @@ MIDDLEWARE_CLASSES = (
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
     'django.middleware.security.SecurityMiddleware',
     'mtp_noms_ops.utils.UserPermissionMiddleware',
-    'mtp_noms_ops.utils.SecurityMiddleware',
+    'mtp_common.analytics.ReferrerPolicyMiddleware',
 )
 
 HEALTHCHECKS = []
@@ -131,6 +131,7 @@ TEMPLATES = [
                 'mtp_noms_ops.apps.security.context_processors.nomis_api_available',
                 'mtp_noms_ops.apps.security.context_processors.prison_choice_available',
                 'mtp_noms_ops.apps.security.context_processors.notifications_available',
+                'mtp_common.analytics.default_genericised_pageview',
             ],
         },
     },

--- a/mtp_noms_ops/templates/security/credits.html
+++ b/mtp_noms_ops/templates/security/credits.html
@@ -13,7 +13,7 @@
 
   {% include 'mtp_common/includes/message_box.html' %}
 
-  <form id="filter-credits" class="mtp-security-search js-FormAnalytics" method="get" data-ga-location="{{ google_analytics_pageview.location }}" data-ga-page="{{ google_analytics_pageview.page }}" data-ga-title="{{ google_analytics_pageview.title }}">
+  <form id="filter-credits" class="mtp-security-search js-FormAnalytics" method="get">
     {% include 'mtp_common/forms/error-summary.html' with form=form only %}
 
     <p class="lede">{{ form.search_description.description }}</p>

--- a/mtp_noms_ops/templates/security/disbursements.html
+++ b/mtp_noms_ops/templates/security/disbursements.html
@@ -13,7 +13,7 @@
 
   {% include 'mtp_common/includes/message_box.html' %}
 
-  <form id="filter-disbursements" class="mtp-security-search js-FormAnalytics" method="get" data-ga-location="{{ google_analytics_pageview.location }}" data-ga-page="{{ google_analytics_pageview.page }}" data-ga-title="{{ google_analytics_pageview.title }}">
+  <form id="filter-disbursements" class="mtp-security-search js-FormAnalytics" method="get">
     {% include 'mtp_common/forms/error-summary.html' with form=form only %}
 
     <p class="lede">

--- a/mtp_noms_ops/templates/security/prisoner.html
+++ b/mtp_noms_ops/templates/security/prisoner.html
@@ -67,7 +67,7 @@
     </div>
   </div>
 
-  <form class="js-FormAnalytics" method="get" data-ga-location="{{ google_analytics_pageview.location }}" data-ga-page="{{ google_analytics_pageview.page }}" data-ga-title="{{ google_analytics_pageview.title }}">
+  <form class="js-FormAnalytics" method="get">
     {% include 'mtp_common/forms/error-summary.html' with form=form only %}
 
     {% if form.is_valid %}

--- a/mtp_noms_ops/templates/security/prisoners.html
+++ b/mtp_noms_ops/templates/security/prisoners.html
@@ -13,7 +13,7 @@
 
   {% include 'mtp_common/includes/message_box.html' %}
 
-  <form id="filter-prisoners" class="mtp-security-search js-FormAnalytics" method="get" data-ga-location="{{ google_analytics_pageview.location }}" data-ga-page="{{ google_analytics_pageview.page }}" data-ga-title="{{ google_analytics_pageview.title }}">
+  <form id="filter-prisoners" class="mtp-security-search js-FormAnalytics" method="get">
     {% include 'mtp_common/forms/error-summary.html' with form=form only %}
 
     <p class="lede">{{ form.search_description.description }}</p>

--- a/mtp_noms_ops/templates/security/sender.html
+++ b/mtp_noms_ops/templates/security/sender.html
@@ -82,7 +82,7 @@
     {% include 'security/includes/save-search.html' with form=form pin_label=_('Monitor this sender on your home page') unpin_label=_('Stop monitoring this sender') only %}
   </div>
 
-  <form class="js-FormAnalytics" method="get" data-ga-location="{{ google_analytics_pageview.location }}" data-ga-page="{{ google_analytics_pageview.page }}" data-ga-title="{{ google_analytics_pageview.title }}">
+  <form class="js-FormAnalytics" method="get">
     {% include 'mtp_common/forms/error-summary.html' with form=form only %}
 
     {% if form.is_valid %}

--- a/mtp_noms_ops/templates/security/senders.html
+++ b/mtp_noms_ops/templates/security/senders.html
@@ -13,7 +13,7 @@
 
   {% include 'mtp_common/includes/message_box.html' %}
 
-  <form id="filter-senders" class="mtp-security-search js-FormAnalytics" method="get" data-ga-location="{{ google_analytics_pageview.location }}" data-ga-page="{{ google_analytics_pageview.page }}" data-ga-title="{{ google_analytics_pageview.title }}">
+  <form id="filter-senders" class="mtp-security-search js-FormAnalytics" method="get">
     {% include 'mtp_common/forms/error-summary.html' with form=form only %}
 
     <p class="lede">{{ form.search_description.description }}</p>

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,4 +1,4 @@
 # Place development dependencies here
 -r base.txt
 
-money-to-prisoners-common[testing]>=9.1,<9.2
+money-to-prisoners-common[testing]>=9.2,<9.3

--- a/requirements/docker.txt
+++ b/requirements/docker.txt
@@ -1,6 +1,6 @@
 # Place docker dependencies here
 -r base.txt
 
-money-to-prisoners-common[monitoring]>=9.1,<9.2
+money-to-prisoners-common[monitoring]>=9.2,<9.3
 
 uWSGI==2.0.17


### PR DESCRIPTION
Send event attributes as positional arguments rather than a dict allows
a final dict argument to override page, location and title.