### PR TITLE
Fix disbursements list not showing up on prisoner profile

### DIFF
--- a/mtp_noms_ops/apps/security/forms/object_detail.py
+++ b/mtp_noms_ops/apps/security/forms/object_detail.py
@@ -1,3 +1,5 @@
+from urllib.parse import urljoin
+
 from django import forms
 from django.utils.translation import gettext_lazy as _
 
@@ -70,27 +72,5 @@ class PrisonersDisbursementDetailForm(PrisonersDetailForm):
     unfiltered_description_template = 'All disbursements sent by this prisoner are shown below ordered by ' \
                                       '{ordering_description}.'
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.prisoner_number = None
-
-    def get_object(self):
-        obj = super().get_object()
-        if obj:
-            self.prisoner_number = obj.get('prisoner_number')
-        return obj
-
-    def get_object_list(self):
-        if not self.prisoner_number:
-            return []
-        return super().get_object_list()
-
     def get_object_list_endpoint_path(self):
-        return '/disbursements/'
-
-    def get_query_data(self, allow_parameter_manipulation=True):
-        data = super().get_query_data(allow_parameter_manipulation=allow_parameter_manipulation)
-        if not self.prisoner_number:
-            self.get_object()
-        data['prisoner_number'] = self.prisoner_number
-        return data
+        return urljoin(self.get_object_endpoint_path(), 'disbursements/')

--- a/mtp_noms_ops/apps/security/tests/test_views.py
+++ b/mtp_noms_ops/apps/security/tests/test_views.py
@@ -1204,7 +1204,9 @@ class PrisonerDetailViewTestCase(SecurityViewTestCase):
             reverse('security:prisoner_detail', kwargs={'prisoner_id': 1})
         )
         self.assertContains(response, 'Stop monitoring this prisoner')
-        self.assertEqual(responses.calls[-2].request.body, b'{"last_result_count": 4}')
+        for call in responses.calls:
+            if call.request.path_url == '/searches/1/':
+                self.assertEqual(call.request.body, b'{"last_result_count": 4}')
 
     @responses.activate
     @override_nomis_settings
@@ -1235,13 +1237,15 @@ class PrisonerDetailViewTestCase(SecurityViewTestCase):
             '?pin=1'
         )
 
-        self.assertEqual(
-            json.loads(responses.calls[-3].request.body.decode()),
-            {
-                'description': 'A1409AE JAMES HALLS',
-                'endpoint': '/prisoners/1/credits/',
-                'last_result_count': 4,
-                'site_url': '/en-gb/security/prisoners/1/',
-                'filters': [{'field': 'ordering', 'value': '-received_at'}],
-            },
-        )
+        for call in responses.calls:
+            if call.request.path_url == '/searches/':
+                self.assertEqual(
+                    json.loads(call.request.body.decode()),
+                    {
+                        'description': 'A1409AE JAMES HALLS',
+                        'endpoint': '/prisoners/1/credits/',
+                        'last_result_count': 4,
+                        'site_url': '/en-gb/security/prisoners/1/',
+                        'filters': [{'field': 'ordering', 'value': '-received_at'}],
+                    },
+                )

--- a/mtp_noms_ops/apps/security/views/object_detail.py
+++ b/mtp_noms_ops/apps/security/views/object_detail.py
@@ -1,7 +1,6 @@
 from django.core.urlresolvers import reverse_lazy
 from django.http import Http404
 from django.utils.translation import gettext, gettext_lazy as _
-from requests.exceptions import RequestException
 
 from security.forms.object_detail import (
     SendersDetailForm,
@@ -131,26 +130,11 @@ class PrisonerDetailView(SecurityDetailView):
             context_data['provided_names'] = NameSet(
                 prisoner.get('provided_names', ()), strip_titles=True
             )
-            context_data['disbursement_count'] = self.get_disbursement_count(
-                context_data['form'].session, prisoner['prisoner_number']
-            )
         return context_data
 
     def get_title_for_object(self, detail_object):
         title = ' '.join(detail_object.get(key, '') for key in ('prisoner_number', 'prisoner_name'))
         return title.strip() or _('Unknown prisoner')
-
-    def get_disbursement_count(self, session, prisoner_number):
-        try:
-            response = session.get('/disbursements/', params={
-                'prisoner_number': prisoner_number,
-                # exclude rejected/cancelled disbursements
-                'resolution': ['pending', 'preconfirmed', 'confirmed', 'sent'],
-                'limit': 1,
-            }).json()
-            return response['count']
-        except (RequestException, ValueError, KeyError):
-            return None
 
 
 class PrisonerDisbursementDetailView(PrisonerDetailView):

--- a/mtp_noms_ops/templates/security/includes/notification-table.html
+++ b/mtp_noms_ops/templates/security/includes/notification-table.html
@@ -149,10 +149,11 @@
               {% endif %}
               {% if notification_class == 'from_many_senders' %}
                 <td>{{ notification.prisoner_profile.sender_count }}</td>
+                <td><a href="{% url 'security:prisoner_detail' notification.prisoner_profile.id %}" title="{% trans 'View prisoner details' %}">{% trans 'View' %}</a></td>
               {% else %}
                 <td>{{ notification.prisoner_profile.recipient_count }}</td>
+                <td><a href="{% url 'security:prisoner_disbursement_detail' notification.prisoner_profile.id %}" title="{% trans 'View prisoner details' %}">{% trans 'View' %}</a></td>
               {% endif %}
-              <td><a href="{% url 'security:prisoner_detail' notification.prisoner_profile.id %}" title="{% trans 'View prisoner details' %}">{% trans 'View' %}</a></td>
             </tr>
           </tbody>
         {% endfor %}

--- a/mtp_noms_ops/templates/security/prisoner.html
+++ b/mtp_noms_ops/templates/security/prisoner.html
@@ -36,7 +36,7 @@
         </div>
 
         <div class="column-one-quarter">
-          {% labelled_data _('Disbursements sent') disbursement_count|default_if_none:_('Unknown') tag='strong' %}
+          {% labelled_data _('Disbursements sent') prisoner.disbursement_count tag='strong' %}
         </div>
       </div>
 


### PR DESCRIPTION
This was due to a change in method ordering meaning that one thing
was not initialised at the correct time. However, the way in which
disbursements were retrieved on the prisoner profile page was due
to be updated to the nested resource anyway, so I have done so.