### PR TITLE
Prison switcher

### DIFF
--- a/mtp_noms_ops/apps/security/context_processors.py
+++ b/mtp_noms_ops/apps/security/context_processors.py
@@ -1,5 +1,7 @@
 from urllib.parse import urlencode
 
+from django.contrib.auth import REDIRECT_FIELD_NAME
+
 from .utils import (
     can_see_notifications, can_choose_prisons, is_nomis_api_configured
 )
@@ -28,3 +30,12 @@ def initial_params(request):
         ('prison', prison['nomis_id'])
         for prison in request.user_prisons
     ], doseq=True)}
+
+
+def common(_):
+    """
+    Context Processor for common / core logic, e.g. making some variable available in the templates.
+    """
+    return {
+        'REDIRECT_FIELD_NAME': REDIRECT_FIELD_NAME,
+    }

--- a/mtp_noms_ops/apps/security/templatetags/security.py
+++ b/mtp_noms_ops/apps/security/templatetags/security.py
@@ -66,7 +66,28 @@ def format_resolution(resolution):
 
 @register.filter
 def list_prison_names(prisons):
+    """
+    Returns prison names in `prisons` as a comma separated string.
+    """
     return ', '.join((prison['name'] for prison in prisons))
+
+
+@register.simple_tag
+def get_split_prison_names(prisons, split_at=3):
+    """
+    Same as `list_prison_names` but only including the first `split_at` prisons.
+
+    Returns a dict with
+        prison_names: first `split_at` prison names in `prisons` as a comma separated string
+        total_remaining: number of remaining prisons that were not included in `prison_names`
+
+    :param prisons: list of dicts with prison data
+    :split_at: number of prisons to be included in the prison_names join.
+    """
+    return {
+        'prison_names': list_prison_names(prisons[:split_at]),
+        'total_remaining': len(prisons[split_at:]),
+    }
 
 
 @register.filter

--- a/mtp_noms_ops/apps/security/tests/test_templatetags.py
+++ b/mtp_noms_ops/apps/security/tests/test_templatetags.py
@@ -1,0 +1,53 @@
+from django.test import SimpleTestCase
+
+from security.templatetags.security import get_split_prison_names
+
+
+class TestGetSplitPrisonNames(SimpleTestCase):
+    """
+    Tests for the get_split_prison_names template tag.
+    """
+
+    def test_without_need_to_split(self):
+        """
+        Test that if the split_at value is >= the number of prisons,
+        prisons_names includes all prisons and total_renaming is 0.
+        """
+        tot_prisons = 5
+
+        prisons = [
+            {'name': f'Prison {index}'}
+            for index in range(tot_prisons)
+        ]
+
+        actual_data = get_split_prison_names(prisons, split_at=tot_prisons)
+        expected_data = {
+            'prison_names': ', '.join(
+                [prison['name'] for prison in prisons],
+            ),
+            'total_remaining': 0,
+        }
+        self.assertEqual(actual_data, expected_data)
+
+    def test_split(self):
+        """
+        Test that if the split_at value is < the number of prisons,
+        prisons_names includes only the first `split_at` prisons and
+        total_renaming is != 0.
+        """
+        tot_prisons = 5
+        split_at = tot_prisons - 1
+
+        prisons = [
+            {'name': f'Prison {index}'}
+            for index in range(tot_prisons)
+        ]
+
+        actual_data = get_split_prison_names(prisons, split_at=split_at)
+        expected_data = {
+            'prison_names': ', '.join(
+                [prison['name'] for prison in prisons[:split_at]],
+            ),
+            'total_remaining': 1,
+        }
+        self.assertEqual(actual_data, expected_data)

--- a/mtp_noms_ops/apps/security/tests/test_views.py
+++ b/mtp_noms_ops/apps/security/tests/test_views.py
@@ -184,6 +184,92 @@ class SecurityDashboardViewsTestCase(SecurityBaseTestCase):
         self.assertContains(response, '<!-- security:dashboard -->')
 
 
+class PrisonSwitcherTestCase(SecurityBaseTestCase):
+    """
+    Tests related to the prison switcher area on the top of some pages.
+    The prison switcher area shows the prisons that the user selected in the settings
+    page with a link to change this.
+    """
+
+    def _mock_api_responses(self):
+        no_saved_searches()
+        sample_prison_list()
+        responses.add(
+            responses.GET,
+            api_url('/senders/'),
+            json={},
+        )
+
+    @responses.activate
+    def test_with_many_prisons(self):
+        """
+        Test that if the user has more than 4 prisons in settings, only the first ones are
+        shown in the prison switcher area to avoid long text.
+        """
+        self._mock_api_responses()
+        prisons = [
+            {
+                **sample_prisons[0],
+                'name': f'Prison {index}',
+            } for index in range(1, 11)
+        ]
+        self.login(
+            user_data=self.get_user_data(prisons=prisons),
+        )
+        response = self.client.get(reverse('security:sender_list'))
+        self.assertContains(
+            response,
+            'Prison 1, Prison 2, Prison 3, Prison 4',
+        )
+        self.assertContains(
+            response,
+            ' and 6 more',
+        )
+
+    @responses.activate
+    def test_with_fewer_prisons(self):
+        """
+        Test that if the user has less than 4 prisons in settings,
+        they are all shown in the prison switcher area.
+        """
+        self._mock_api_responses()
+        prisons = [
+            {
+                **sample_prisons[0],
+                'name': f'Prison {index}',
+            } for index in range(1, 3)
+        ]
+        self.login(
+            user_data=self.get_user_data(prisons=prisons),
+        )
+        response = self.client.get(reverse('security:sender_list'))
+        self.assertContains(
+            response,
+            'Prison 1, Prison 2',
+        )
+
+        self.assertNotContains(
+            response,
+            'Prison 3',
+        )
+
+    @responses.activate
+    def test_sees_all_prisons(self):
+        """
+        Test that if the user hasn't specified any prisons in settings, it means that he/she can
+        see all prisons so the text 'All prisons' is known in the prison switcher area.
+        """
+        self._mock_api_responses()
+        self.login(
+            user_data=self.get_user_data(prisons=[]),
+        )
+        response = self.client.get(reverse('security:sender_list'))
+        self.assertContains(
+            response,
+            'All prisons',
+        )
+
+
 class HMPPSEmployeeTestCase(SecurityBaseTestCase):
     protected_views = ['security:dashboard', 'security:credit_list', 'security:sender_list', 'security:prisoner_list']
 

--- a/mtp_noms_ops/apps/settings/views.py
+++ b/mtp_noms_ops/apps/settings/views.py
@@ -1,7 +1,10 @@
 from urllib.parse import urlencode
 
-from django.core.urlresolvers import reverse_lazy
+from django.core.urlresolvers import reverse, reverse_lazy
+from django.contrib.auth import REDIRECT_FIELD_NAME
+from django.contrib.auth.views import SuccessURLAllowedHostsMixin
 from django.shortcuts import redirect
+from django.utils.http import is_safe_url
 from django.utils.translation import gettext_lazy as _
 from django.views.generic import FormView, TemplateView
 from mtp_common.auth.api_client import get_api_session
@@ -80,11 +83,27 @@ class ConfirmPrisonsView(FormView):
         return self.success_url
 
 
-class ChangePrisonsView(FormView):
+class ChangePrisonsView(SuccessURLAllowedHostsMixin, FormView):
     title = _('Change prisons')
     template_name = 'settings/confirm-prisons-change.html'
     form_class = ChangePrisonForm
-    success_url = reverse_lazy('settings')
+
+    def get_success_url(self):
+        """
+        Returns the REDIRECT_FIELD_NAME value in GET if it exists and it's valid
+        or the url to the settings page otherwise.
+        """
+        if REDIRECT_FIELD_NAME in self.request.GET:
+            next_page = self.request.GET[REDIRECT_FIELD_NAME]
+            url_is_safe = is_safe_url(
+                url=next_page,
+                allowed_hosts=self.get_success_url_allowed_hosts(),
+                require_https=self.request.is_secure(),
+            )
+
+            if url_is_safe:
+                return next_page
+        return reverse('settings')
 
     def get_context_data(self, *args, **kwargs):
         context = super().get_context_data(*args, **kwargs)

--- a/mtp_noms_ops/assets-src/stylesheets/app.scss
+++ b/mtp_noms_ops/assets-src/stylesheets/app.scss
@@ -15,6 +15,7 @@
 @import 'views/review';
 @import 'views/save-search';
 @import 'views/choose-prisons';
+@import 'views/prison_switcher';
 
 // govuk elements overrides
 

--- a/mtp_noms_ops/assets-src/stylesheets/views/_prison_switcher.scss
+++ b/mtp_noms_ops/assets-src/stylesheets/views/_prison_switcher.scss
@@ -1,0 +1,25 @@
+.mtp-prison-switcher {
+  @extend %site-width-container;
+
+  padding: 10px 0 5px;
+  border-bottom: 1px solid $border-colour;
+
+  .mtp-prison-switcher__prison-names {
+    float: left;
+    width: 80%;
+    font-size: 20px;
+    font-weight: bold;
+  }
+
+  .mtp-prison-switcher__change-link {
+    float: left;
+    width: 20%;
+    text-align: right;
+  }
+
+  &:after {
+    content: "";
+    clear: both;
+    display: block;
+  }
+}

--- a/mtp_noms_ops/settings/base.py
+++ b/mtp_noms_ops/settings/base.py
@@ -126,6 +126,7 @@ TEMPLATES = [
                 'mtp_common.context_processors.app_environment',
                 'mtp_noms_ops.utils.govuk_localisation',
                 'mtp_noms_ops.utils.external_breadcrumbs',
+                'mtp_noms_ops.apps.security.context_processors.common',
                 'mtp_noms_ops.apps.security.context_processors.initial_params',
                 'mtp_noms_ops.apps.security.context_processors.nomis_api_available',
                 'mtp_noms_ops.apps.security.context_processors.prison_choice_available',

--- a/mtp_noms_ops/templates/security/credits.html
+++ b/mtp_noms_ops/templates/security/credits.html
@@ -5,6 +5,11 @@
 
 {% block page_title %}{{ view.title }} – {{ block.super }}{% endblock %}
 
+{% block phase_banner %}
+  {{ block.super }}
+  {% include "security/forms/prison-switcher.html" %}
+{% endblock %}
+
 {% block inner_content %}
 
   <header>

--- a/mtp_noms_ops/templates/security/disbursements.html
+++ b/mtp_noms_ops/templates/security/disbursements.html
@@ -5,6 +5,11 @@
 
 {% block page_title %}{{ view.title }} – {{ block.super }}{% endblock %}
 
+{% block phase_banner %}
+  {{ block.super }}
+  {% include "security/forms/prison-switcher.html" %}
+{% endblock %}
+
 {% block inner_content %}
 
   <header>

--- a/mtp_noms_ops/templates/security/forms/prison-switcher.html
+++ b/mtp_noms_ops/templates/security/forms/prison-switcher.html
@@ -1,24 +1,26 @@
 {% load i18n security %}
 
-<div class="mtp-prison-switcher print-hidden">
-  <div class="mtp-prison-switcher__prison-names">
-    {% if not user.user_data.prisons %}
-      {% trans 'All prisons' %}
-    {% else %}
-      {% get_split_prison_names user.user_data.prisons 4 as split_prison_names %}
-
-      {{ split_prison_names.prison_names }}
-
-      {% if split_prison_names.total_remaining %}
-        {% blocktrans trimmed with total_remaining=split_prison_names.total_remaining %}
-          and {{ total_remaining }} more
-        {% endblocktrans %}
+{% if request.can_see_search_v2 %}
+  <div class="mtp-prison-switcher print-hidden">
+    <div class="mtp-prison-switcher__prison-names">
+      {% if not user.user_data.prisons %}
+        {% trans 'All prisons' %}
       {% else %}
-      {% endif %}
-    {% endif %}
-  </div>
+        {% get_split_prison_names user.user_data.prisons 4 as split_prison_names %}
 
-  <div class="mtp-prison-switcher__change-link">
-    <a href="{% url 'change_prisons' %}?{{ REDIRECT_FIELD_NAME }}={{ request.path|urlencode }}?{{ request.GET.urlencode|urlencode }}">{% trans 'Change' %}</a>
+        {{ split_prison_names.prison_names }}
+
+        {% if split_prison_names.total_remaining %}
+          {% blocktrans trimmed with total_remaining=split_prison_names.total_remaining %}
+            and {{ total_remaining }} more
+          {% endblocktrans %}
+        {% else %}
+        {% endif %}
+      {% endif %}
+    </div>
+
+    <div class="mtp-prison-switcher__change-link">
+      <a href="{% url 'change_prisons' %}?{{ REDIRECT_FIELD_NAME }}={{ request.path|urlencode }}?{{ request.GET.urlencode|urlencode }}">{% trans 'Change' %}</a>
+    </div>
   </div>
-</div>
+{% endif %}

--- a/mtp_noms_ops/templates/security/forms/prison-switcher.html
+++ b/mtp_noms_ops/templates/security/forms/prison-switcher.html
@@ -1,0 +1,24 @@
+{% load i18n security %}
+
+<div class="mtp-prison-switcher print-hidden">
+  <div class="mtp-prison-switcher__prison-names">
+    {% if not user.user_data.prisons %}
+      {% trans 'All prisons' %}
+    {% else %}
+      {% get_split_prison_names user.user_data.prisons 4 as split_prison_names %}
+
+      {{ split_prison_names.prison_names }}
+
+      {% if split_prison_names.total_remaining %}
+        {% blocktrans trimmed with total_remaining=split_prison_names.total_remaining %}
+          and {{ total_remaining }} more
+        {% endblocktrans %}
+      {% else %}
+      {% endif %}
+    {% endif %}
+  </div>
+
+  <div class="mtp-prison-switcher__change-link">
+    <a href="{% url 'change_prisons' %}?{{REDIRECT_FIELD_NAME}}={{request.path|urlencode}}">{% trans 'Change' %}</a>
+  </div>
+</div>

--- a/mtp_noms_ops/templates/security/forms/prison-switcher.html
+++ b/mtp_noms_ops/templates/security/forms/prison-switcher.html
@@ -19,6 +19,6 @@
   </div>
 
   <div class="mtp-prison-switcher__change-link">
-    <a href="{% url 'change_prisons' %}?{{REDIRECT_FIELD_NAME}}={{request.path|urlencode}}">{% trans 'Change' %}</a>
+    <a href="{% url 'change_prisons' %}?{{ REDIRECT_FIELD_NAME }}={{ request.path|urlencode }}?{{ request.GET.urlencode|urlencode }}">{% trans 'Change' %}</a>
   </div>
 </div>

--- a/mtp_noms_ops/templates/security/prisoners.html
+++ b/mtp_noms_ops/templates/security/prisoners.html
@@ -5,6 +5,11 @@
 
 {% block page_title %}{{ view.title }} – {{ block.super }}{% endblock %}
 
+{% block phase_banner %}
+  {{ block.super }}
+  {% include "security/forms/prison-switcher.html" %}
+{% endblock %}
+
 {% block inner_content %}
 
   <header>

--- a/mtp_noms_ops/templates/security/review.html
+++ b/mtp_noms_ops/templates/security/review.html
@@ -5,6 +5,11 @@
 
 {% block page_title %}{{ view.title }} – {{ block.super }}{% endblock %}
 
+{% block phase_banner %}
+  {{ block.super }}
+  {% include "security/forms/prison-switcher.html" %}
+{% endblock %}
+
 {% block inner_content %}
 <header>
   <h1 class="heading-xlarge">{{ view.title }}</h1>

--- a/mtp_noms_ops/templates/security/senders.html
+++ b/mtp_noms_ops/templates/security/senders.html
@@ -7,6 +7,7 @@
 
 {% block page_title %}{{ view.title }} – {{ block.super }}{% endblock %}
 
+
 {% block inner_content %}
 
   <header>

--- a/mtp_noms_ops/templates/security/senders_list.html
+++ b/mtp_noms_ops/templates/security/senders_list.html
@@ -5,6 +5,11 @@
 
 {% block page_title %}{{ view.title }} – {{ block.super }}{% endblock %}
 
+{% block phase_banner %}
+  {{ block.super }}
+  {% include "security/forms/prison-switcher.html" %}
+{% endblock %}
+
 {% block inner_content %}
   <form id="filter-senders" class="mtp-security-search js-FormAnalytics" method="get">
 

--- a/mtp_noms_ops/utils.py
+++ b/mtp_noms_ops/utils.py
@@ -6,7 +6,7 @@ from django.utils.translation import gettext, gettext_lazy as _
 from mtp_common.context_processors import govuk_localisation as inherited_localisation
 
 from prisoner_location_admin import required_permissions as prisoner_location_permissions
-from security import required_permissions as security_permissions
+from security import required_permissions as security_permissions, SEARCH_V2_FLAG
 
 
 class UserPermissionMiddleware:
@@ -20,6 +20,7 @@ class UserPermissionMiddleware:
             prison['pre_approval_required']
             for prison in request.user_prisons
         )
+        request.can_see_search_v2 = SEARCH_V2_FLAG in request.user.user_data.get('flags', [])
 
 
 class SecurityMiddleware(MiddlewareMixin):


### PR DESCRIPTION
This adds a new Prison Switcher area to the top of some pages showing the first 4 prisons the user has set in his/her settings with a link to the exiting page responsible for changing this if needed.

If more than 4 prisons exist in the user settings, a 'x more' text is shown as well.

The user is redirected back to the page he/she was coming from after saving the form via the prison switcher.

I added the section to the new `security/base.html` template as it only applies to security pages but that makes it a bit weird as the dashboard now extends `security/base.html`. This dashboard template should really be in the `security` folder but it was already in the root folder so I'm okay to keep it this way.
@ushkarev let me know if you have anything else in mind instead.

<img width="1016" alt="Screenshot 2019-07-08 at 16 21 39" src="https://user-images.githubusercontent.com/178865/60822518-7cf6d780-a19d-11e9-9c08-3a72952ac5b4.png">
