### PR TITLE
Credits simple search box

### DIFF
--- a/mtp_noms_ops/apps/security/forms/object_list.py
+++ b/mtp_noms_ops/apps/security/forms/object_list.py
@@ -319,6 +319,11 @@ class BaseCreditsForm(SecurityForm):
     )
     prison = forms.MultipleChoiceField(label=_('Prison'), required=False, choices=[])
 
+    def get_object_list(self):
+        object_list = super().get_object_list()
+        parse_date_fields(object_list)
+        return object_list
+
     def get_object_list_endpoint_path(self):
         return '/credits/'
 
@@ -455,9 +460,6 @@ class CreditsForm(BaseCreditsForm):
         if sender_postcode:
             sender_postcode = re.sub(r'[\s-]+', '', sender_postcode).upper()
         return sender_postcode
-
-    def get_object_list(self):
-        return parse_date_fields(super().get_object_list())
 
     def get_query_data(self, allow_parameter_manipulation=True):
         query_data = super().get_query_data(allow_parameter_manipulation=allow_parameter_manipulation)

--- a/mtp_noms_ops/apps/security/tests/test_forms.py
+++ b/mtp_noms_ops/apps/security/tests/test_forms.py
@@ -512,7 +512,7 @@ class CreditFormV2TestCase(SecurityFormTestCase):
                 'page': 1,
                 'ordering': '-received_at',
                 'prison': [],
-                'search': '',
+                'simple_search': '',
             },
         )
         self.assertDictEqual(
@@ -540,7 +540,7 @@ class CreditFormV2TestCase(SecurityFormTestCase):
                     'prison': [
                         prisons[0]['nomis_id'],
                     ],
-                    'search': 'Joh',
+                    'simple_search': 'Joh',
                 },
             )
 
@@ -548,7 +548,7 @@ class CreditFormV2TestCase(SecurityFormTestCase):
             self.assertListEqual(form.get_object_list(), [])
             self.assertEqual(
                 urlsplit(rsps.calls[-1].request.url).query,
-                'offset=20&limit=20&ordering=-amount&prison=IXB&search=Joh',
+                'offset=20&limit=20&ordering=-amount&prison=IXB&simple_search=Joh',
             )
 
         self.assertDictEqual(
@@ -559,7 +559,7 @@ class CreditFormV2TestCase(SecurityFormTestCase):
                 'prison': [
                     prisons[0]['nomis_id'],
                 ],
-                'search': 'Joh',
+                'simple_search': 'Joh',
             },
         )
 
@@ -570,7 +570,7 @@ class CreditFormV2TestCase(SecurityFormTestCase):
                 'prison': [
                     prisons[0]['nomis_id'],
                 ],
-                'search': 'Joh',
+                'simple_search': 'Joh',
             },
         )
 

--- a/mtp_noms_ops/apps/security/tests/test_forms.py
+++ b/mtp_noms_ops/apps/security/tests/test_forms.py
@@ -16,10 +16,14 @@ from security.forms.object_list import (
     SendersFormV2,
     PrisonersForm,
     CreditsForm,
+    CreditsFormV2,
     DisbursementsForm,
 )
 from security.forms.review import ReviewCreditsForm
 from security.tests import api_url
+
+
+ValidationScenario = namedtuple('ValidationScenario', 'data errors')
 
 
 def mock_prison_response(rsps):
@@ -166,7 +170,7 @@ class SenderFormTestCase(SecurityFormTestCase):
         with responses.RequestsMock() as rsps:
             mock_prison_response(rsps)
             mock_empty_response(rsps, self.api_list_path)
-            form = SendersForm(self.request, data={'page': '1'})
+            form = self.form_class(self.request, data={'page': '1'})
             self.assertTrue(form.is_valid())
             self.assertDictEqual(form.cleaned_data, expected_data)
             self.assertListEqual(form.get_object_list(), [])
@@ -187,7 +191,7 @@ class SenderFormTestCase(SecurityFormTestCase):
         with responses.RequestsMock() as rsps:
             mock_prison_response(rsps)
             mock_empty_response(rsps, self.api_list_path)
-            form = SendersForm(self.request, data={'page': '1', 'ordering': '-credit_total', 'sender_name': 'Joh '})
+            form = self.form_class(self.request, data={'page': '1', 'ordering': '-credit_total', 'sender_name': 'Joh '})
             self.assertTrue(form.is_valid())
             self.assertDictEqual(form.cleaned_data, expected_data)
             self.assertListEqual(form.get_object_list(), [])
@@ -197,17 +201,17 @@ class SenderFormTestCase(SecurityFormTestCase):
     def test_sender_list_invalid_forms(self):
         with responses.RequestsMock() as rsps:
             mock_prison_response(rsps)
-            form = SendersForm(self.request, data={'page': '0'})
+            form = self.form_class(self.request, data={'page': '0'})
         self.assertFalse(form.is_valid())
 
         with responses.RequestsMock() as rsps:
             mock_prison_response(rsps)
-            form = SendersForm(self.request, data={'page': '1', 'ordering': 'prison'})
+            form = self.form_class(self.request, data={'page': '1', 'ordering': 'prison'})
         self.assertFalse(form.is_valid())
 
         with responses.RequestsMock() as rsps:
             mock_prison_response(rsps)
-            form = SendersForm(self.request, data={'page': '1', 'prison': 'ABC'})
+            form = self.form_class(self.request, data={'page': '1', 'prison': 'ABC'})
         self.assertFalse(form.is_valid())
 
 
@@ -227,7 +231,7 @@ class SenderFormV2TestCase(SecurityFormTestCase):
             mock_prison_response(rsps)
             mock_empty_response(rsps, self.api_list_path)
 
-            form = SendersFormV2(self.request, data={})
+            form = self.form_class(self.request, data={})
             self.assertTrue(form.is_valid())
             self.assertListEqual(form.get_object_list(), [])
             self.assertEqual(
@@ -261,7 +265,7 @@ class SenderFormV2TestCase(SecurityFormTestCase):
             prisons = mock_prison_response(rsps)
             mock_empty_response(rsps, self.api_list_path)
 
-            form = SendersFormV2(
+            form = self.form_class(
                 self.request,
                 data={
                     'page': 2,
@@ -307,8 +311,6 @@ class SenderFormV2TestCase(SecurityFormTestCase):
         """
         Test validation errors.
         """
-        ValidationScenario = namedtuple('ValidationScenario', 'data errors')
-
         scenarios = [
             ValidationScenario(
                 {'page': '0'},
@@ -327,7 +329,7 @@ class SenderFormV2TestCase(SecurityFormTestCase):
         for scenario in scenarios:
             with responses.RequestsMock() as rsps:
                 mock_prison_response(rsps)
-                form = SendersFormV2(self.request, data=scenario.data)
+                form = self.form_class(self.request, data=scenario.data)
             self.assertFalse(form.is_valid())
             self.assertDictEqual(form.errors, scenario.errors)
 
@@ -352,7 +354,7 @@ class PrisonerFormTestCase(SecurityFormTestCase):
         with responses.RequestsMock() as rsps:
             mock_prison_response(rsps)
             mock_empty_response(rsps, self.api_list_path)
-            form = PrisonersForm(self.request, data={'page': '1'})
+            form = self.form_class(self.request, data={'page': '1'})
             self.assertTrue(form.is_valid())
             self.assertDictEqual(form.cleaned_data, expected_data)
             self.assertListEqual(form.get_object_list(), [])
@@ -375,7 +377,7 @@ class PrisonerFormTestCase(SecurityFormTestCase):
         with responses.RequestsMock() as rsps:
             mock_prison_response(rsps)
             mock_empty_response(rsps, self.api_list_path)
-            form = PrisonersForm(
+            form = self.form_class(
                 self.request,
                 data={'page': '1', 'ordering': '-credit_total', 'prisoner_name': ' John'},
             )
@@ -388,21 +390,24 @@ class PrisonerFormTestCase(SecurityFormTestCase):
     def test_prisoner_list_invalid_forms(self):
         with responses.RequestsMock() as rsps:
             mock_prison_response(rsps)
-            form = PrisonersForm(self.request, data={'page': '0'})
+            form = self.form_class(self.request, data={'page': '0'})
         self.assertFalse(form.is_valid())
 
         with responses.RequestsMock() as rsps:
             mock_prison_response(rsps)
-            form = PrisonersForm(self.request, data={'page': '1', 'ordering': 'prison'})
+            form = self.form_class(self.request, data={'page': '1', 'ordering': 'prison'})
         self.assertFalse(form.is_valid())
 
         with responses.RequestsMock() as rsps:
             mock_prison_response(rsps)
-            form = PrisonersForm(self.request, data={'page': '1', 'prison': 'ABC'})
+            form = self.form_class(self.request, data={'page': '1', 'prison': 'ABC'})
         self.assertFalse(form.is_valid())
 
 
 class CreditFormTestCase(SecurityFormTestCase):
+    """
+    TODO: delete after search V2 goes live.
+    """
     form_class = CreditsForm
     api_list_path = '/credits/'
 
@@ -420,7 +425,7 @@ class CreditFormTestCase(SecurityFormTestCase):
         with responses.RequestsMock() as rsps:
             mock_prison_response(rsps)
             mock_empty_response(rsps, self.api_list_path)
-            form = CreditsForm(self.request, data={'page': '1'})
+            form = self.form_class(self.request, data={'page': '1'})
             self.assertTrue(form.is_valid())
             self.assertDictEqual(form.cleaned_data, expected_data)
             self.assertListEqual(form.get_object_list(), [])
@@ -442,7 +447,10 @@ class CreditFormTestCase(SecurityFormTestCase):
         with responses.RequestsMock() as rsps:
             mock_prison_response(rsps)
             mock_empty_response(rsps, self.api_list_path)
-            form = CreditsForm(self.request, data={'page': '1', 'ordering': '-amount', 'received_at__gte': '26/5/2016'})
+            form = self.form_class(
+                self.request,
+                data={'page': '1', 'ordering': '-amount', 'received_at__gte': '26/5/2016'},
+            )
             self.assertTrue(form.is_valid())
             self.assertDictEqual(form.cleaned_data, expected_data)
             self.assertListEqual(form.get_object_list(), [])
@@ -451,7 +459,7 @@ class CreditFormTestCase(SecurityFormTestCase):
 
         with responses.RequestsMock() as rsps:
             mock_prison_response(rsps)
-            form = CreditsForm(self.request, data={'page': '1', 'amount_pattern': 'not_integral'})
+            form = self.form_class(self.request, data={'page': '1', 'amount_pattern': 'not_integral'})
         self.assertTrue(form.is_valid(), msg=form.errors.as_text())
         self.assertDictEqual(form.get_query_data(), {'ordering': '-received_at', 'exclude_amount__endswith': '00'})
         self.assertDictEqual(form.get_query_data(allow_parameter_manipulation=False),
@@ -461,18 +469,136 @@ class CreditFormTestCase(SecurityFormTestCase):
     def test_credits_list_invalid_forms(self):
         with responses.RequestsMock() as rsps:
             mock_prison_response(rsps)
-            form = CreditsForm(self.request, data={'page': '0'})
+            form = self.form_class(self.request, data={'page': '0'})
         self.assertFalse(form.is_valid())
 
         with responses.RequestsMock() as rsps:
             mock_prison_response(rsps)
-            form = CreditsForm(self.request, data={'page': '1', 'ordering': 'prison'})
+            form = self.form_class(self.request, data={'page': '1', 'ordering': 'prison'})
         self.assertFalse(form.is_valid())
 
         with responses.RequestsMock() as rsps:
             mock_prison_response(rsps)
-            form = CreditsForm(self.request, data={'page': '1', 'prison': 'ABC'})
+            form = self.form_class(self.request, data={'page': '1', 'prison': 'ABC'})
         self.assertFalse(form.is_valid())
+
+
+class CreditFormV2TestCase(SecurityFormTestCase):
+    """
+    Tests related to the CreditFormV2.
+    """
+    form_class = CreditsFormV2
+    api_list_path = '/credits/'
+
+    def test_blank_form(self):
+        """
+        Test that if no data is passed in, the default values are used instead.
+        """
+        with responses.RequestsMock() as rsps:
+            mock_prison_response(rsps)
+            mock_empty_response(rsps, self.api_list_path)
+
+            form = self.form_class(self.request, data={})
+            self.assertTrue(form.is_valid())
+            self.assertListEqual(form.get_object_list(), [])
+            self.assertEqual(
+                urlsplit(rsps.calls[-1].request.url).query,
+                'offset=0&limit=20&ordering=-received_at',
+            )
+
+        self.assertDictEqual(
+            form.cleaned_data,
+            {
+                'page': 1,
+                'ordering': '-received_at',
+                'prison': [],
+                'search': '',
+            },
+        )
+        self.assertDictEqual(
+            form.get_query_data(),
+            {'ordering': '-received_at'},
+        )
+        self.assertEqual(
+            form.query_string,
+            'ordering=-received_at',
+        )
+
+    def test_valid(self):
+        """
+        Test that if data is passed in, the API query string is constructed as expected.
+        """
+        with responses.RequestsMock() as rsps:
+            prisons = mock_prison_response(rsps)
+            mock_empty_response(rsps, self.api_list_path)
+
+            form = self.form_class(
+                self.request,
+                data={
+                    'page': 2,
+                    'ordering': '-amount',
+                    'prison': [
+                        prisons[0]['nomis_id'],
+                    ],
+                    'search': 'Joh',
+                },
+            )
+
+            self.assertTrue(form.is_valid())
+            self.assertListEqual(form.get_object_list(), [])
+            self.assertEqual(
+                urlsplit(rsps.calls[-1].request.url).query,
+                'offset=20&limit=20&ordering=-amount&prison=IXB&search=Joh',
+            )
+
+        self.assertDictEqual(
+            form.cleaned_data,
+            {
+                'page': 2,
+                'ordering': '-amount',
+                'prison': [
+                    prisons[0]['nomis_id'],
+                ],
+                'search': 'Joh',
+            },
+        )
+
+        self.assertDictEqual(
+            form.get_query_data(),
+            {
+                'ordering': '-amount',
+                'prison': [
+                    prisons[0]['nomis_id'],
+                ],
+                'search': 'Joh',
+            },
+        )
+
+    def test_invalid(self):
+        """
+        Test validation errors.
+        """
+        scenarios = [
+            ValidationScenario(
+                {'page': '0'},
+                {'page': ['Ensure this value is greater than or equal to 1.']},
+            ),
+            ValidationScenario(
+                {'ordering': 'prison'},
+                {'ordering': ['Select a valid choice. prison is not one of the available choices.']},
+            ),
+            ValidationScenario(
+                {'prison': ['invalid']},
+                {'prison': ['Select a valid choice. invalid is not one of the available choices.']},
+            ),
+        ]
+
+        for scenario in scenarios:
+            with responses.RequestsMock() as rsps:
+                mock_prison_response(rsps)
+                form = self.form_class(self.request, data=scenario.data)
+            self.assertFalse(form.is_valid())
+            self.assertDictEqual(form.errors, scenario.errors)
 
 
 class DisbursementFormTestCase(SecurityFormTestCase):
@@ -494,7 +620,7 @@ class DisbursementFormTestCase(SecurityFormTestCase):
         with responses.RequestsMock() as rsps:
             mock_prison_response(rsps)
             mock_empty_response(rsps, self.api_list_path)
-            form = DisbursementsForm(self.request, data={'page': '1'})
+            form = self.form_class(self.request, data={'page': '1'})
             self.assertTrue(form.is_valid())
             self.assertDictEqual(form.cleaned_data, expected_data)
             self.assertListEqual(form.get_object_list(), [])
@@ -517,7 +643,7 @@ class DisbursementFormTestCase(SecurityFormTestCase):
         with responses.RequestsMock() as rsps:
             mock_prison_response(rsps)
             mock_empty_response(rsps, self.api_list_path)
-            form = DisbursementsForm(
+            form = self.form_class(
                 self.request,
                 data={'page': '1', 'ordering': '-amount', 'created__gte': '26/5/2016'},
             )
@@ -529,7 +655,7 @@ class DisbursementFormTestCase(SecurityFormTestCase):
 
         with responses.RequestsMock() as rsps:
             mock_prison_response(rsps)
-            form = DisbursementsForm(self.request, data={'page': '1', 'amount_pattern': 'not_integral'})
+            form = self.form_class(self.request, data={'page': '1', 'amount_pattern': 'not_integral'})
         self.assertTrue(form.is_valid(), msg=form.errors.as_text())
         self.assertDictEqual(form.get_query_data(), {'ordering': '-created', 'exclude_amount__endswith': '00'})
         self.assertDictEqual(form.get_query_data(allow_parameter_manipulation=False),
@@ -539,17 +665,17 @@ class DisbursementFormTestCase(SecurityFormTestCase):
     def test_disbursements_list_invalid_forms(self):
         with responses.RequestsMock() as rsps:
             mock_prison_response(rsps)
-            form = DisbursementsForm(self.request, data={'page': '0'})
+            form = self.form_class(self.request, data={'page': '0'})
         self.assertFalse(form.is_valid())
 
         with responses.RequestsMock() as rsps:
             mock_prison_response(rsps)
-            form = DisbursementsForm(self.request, data={'page': '1', 'ordering': 'prison'})
+            form = self.form_class(self.request, data={'page': '1', 'ordering': 'prison'})
         self.assertFalse(form.is_valid())
 
         with responses.RequestsMock() as rsps:
             mock_prison_response(rsps)
-            form = DisbursementsForm(self.request, data={'page': '1', 'prison': 'ABC'})
+            form = self.form_class(self.request, data={'page': '1', 'prison': 'ABC'})
         self.assertFalse(form.is_valid())
 
 

--- a/mtp_noms_ops/apps/security/tests/test_views.py
+++ b/mtp_noms_ops/apps/security/tests/test_views.py
@@ -60,9 +60,10 @@ sample_prisons = [
 default_user_prisons = (sample_prisons[1],)
 
 
-def sample_prison_list():
-    responses.add(
-        responses.GET,
+def sample_prison_list(rsps=None):
+    rsps = rsps or responses
+    rsps.add(
+        rsps.GET,
         api_url('/prisons/'),
         json={
             'count': len(sample_prisons),
@@ -71,9 +72,10 @@ def sample_prison_list():
     )
 
 
-def no_saved_searches():
-    responses.add(
-        responses.GET,
+def no_saved_searches(rsps=None):
+    rsps = rsps or responses
+    rsps.add(
+        rsps.GET,
         api_url('/searches/'),
         json={
             'count': 0,
@@ -98,8 +100,8 @@ class SecurityBaseTestCase(SimpleTestCase):
         super().tearDown()
 
     @mock.patch('mtp_common.auth.backends.api_client')
-    def login(self, mock_api_client, follow=True, user_data=None):
-        no_saved_searches()
+    def login(self, mock_api_client, follow=True, user_data=None, rsps=None):
+        no_saved_searches(rsps=rsps)
         return self._login(mock_api_client, follow=follow, user_data=user_data)
 
     @mock.patch('mtp_common.auth.backends.api_client')
@@ -406,11 +408,10 @@ class HMPPSEmployeeTestCase(SecurityBaseTestCase):
 
 
 class SecurityViewTestCase(SecurityBaseTestCase):
-    """
-    TODO: delete after search V2 goes live.
-    """
     view_name = None
     api_list_path = None
+    search_ordering = None
+
     bank_transfer_sender = {
         'id': 9,
         'credit_count': 4,
@@ -480,6 +481,12 @@ class SecurityViewTestCase(SecurityBaseTestCase):
         'intended_recipient': None,
     }
 
+    def get_api_object_list_response_data(self):
+        """
+        Return the list of objects that the mocked api should return in the tests.
+        """
+        return []
+
     @responses.activate
     @mock.patch('security.forms.object_base.SecurityForm.get_object_list')
     def test_can_access_security_view(self, mocked_form_method):
@@ -529,6 +536,267 @@ class SecurityViewTestCase(SecurityBaseTestCase):
         calls = list(filter(lambda call: self.api_list_path in call.request.url, responses.calls))
         self.assertEqual(len(calls), 1)
         self.assertIn('prison=AAI&prison=BBI', calls[0].request.url)
+
+
+class SimpleSearchV2SecurityTestCaseMixin:
+    search_results_view_name = None
+
+    def get_user_data(
+        self,
+        *args,
+        flags=(
+            hmpps_employee_flag,
+            confirmed_prisons_flag,
+            SEARCH_V2_FLAG,
+        ),
+        **kwargs,
+    ):
+        """
+        Sets the SEARCH_V2_FLAG feature flag by default.
+        """
+
+        return super().get_user_data(*args, flags=flags, **kwargs)
+
+    def test_simple_search_displays_search_results(self):
+        """
+        Test that the search results page includes the objects returned by the API.
+        """
+        with responses.RequestsMock() as rsps:
+            self.login(rsps=rsps)
+            sample_prison_list(rsps=rsps)
+            rsps.add(
+                rsps.GET,
+                api_url(self.api_list_path),
+                json={
+                    'count': 2,
+                    'results': self.get_api_object_list_response_data(),
+                },
+            )
+            response = self.client.get(reverse(self.view_name))
+        self._test_simple_search_search_results_content(response)
+
+    def _test_simple_search_search_results_content(self, response):
+        """
+        Subclass to test that the response content of the search results view is as expected.
+        """
+        raise NotImplementedError
+
+    def test_simple_search_uses_default_prisons(self):
+        """
+        Test that the simple search template uses the prisons of the logged in user to
+        populate the `prison` hidden inputs.
+        The simple search filters by the user's prisons by default.
+        """
+        with responses.RequestsMock() as rsps:
+            user_prisons = sample_prisons
+            user_data = self.get_user_data(prisons=user_prisons)
+
+            self.login(user_data=user_data, rsps=rsps)
+            sample_prison_list(rsps=rsps)
+            response = self.client.get(reverse(self.view_name))
+
+        for prison in user_prisons:
+            self.assertContains(
+                response,
+                f'<input type="hidden" name="prison" value="{prison["nomis_id"]}" />',
+            )
+
+    def test_simple_search_redirects_to_search_results_page(self):
+        """
+        Test that submitting the form redirects to the results page when the form is valid.
+        The action of submitting the form is represented by the query param
+        SIMPLE_SEARCH_FORM_SUBMITTED_INPUT_NAME which gets removed when redirecting.
+        """
+        with responses.RequestsMock() as rsps:
+            self.login(rsps=rsps)
+            sample_prison_list(rsps=rsps)
+            rsps.add(
+                rsps.GET,
+                api_url(self.api_list_path),
+                json={
+                    'count': 0,
+                    'results': [],
+                },
+            )
+            query_string = f'ordering={self.search_ordering}&search=test'
+            request_url = f'{reverse(self.view_name)}?{query_string}&{SIMPLE_SEARCH_FORM_SUBMITTED_INPUT_NAME}=1'
+            expected_redirect_url = f'{reverse(self.search_results_view_name)}?{query_string}'
+            response = self.client.get(request_url)
+            self.assertRedirects(
+                response,
+                expected_redirect_url,
+            )
+
+    def test_doesnt_redirect_to_search_results_page_if_form_is_invalid(self):
+        """
+        Test that submitting the form doesn't redirect to the results page when the form is invalid.
+        The action of submitting the form is represented by the query param
+        SIMPLE_SEARCH_FORM_SUBMITTED_INPUT_NAME.
+        """
+        with responses.RequestsMock() as rsps:
+            self.login(rsps=rsps)
+            sample_prison_list(rsps=rsps)
+            query_string = 'ordering=invalid&search=test'
+            request_url = f'{reverse(self.view_name)}?{query_string}&{SIMPLE_SEARCH_FORM_SUBMITTED_INPUT_NAME}=1'
+            response = self.client.get(request_url)
+            self.assertEqual(response.status_code, 200)
+
+    def test_navigating_back_to_simple_search_form(self):
+        """
+        Test that going back to the simple search form doesn't redirect to the results page.
+        The action of NOT submitting the form explicitly is represented by the absence of query param
+        SIMPLE_SEARCH_FORM_SUBMITTED_INPUT_NAME.
+        """
+        with responses.RequestsMock() as rsps:
+            self.login(rsps=rsps)
+            sample_prison_list(rsps=rsps)
+            rsps.add(
+                rsps.GET,
+                api_url(self.api_list_path),
+                json={
+                    'count': 0,
+                    'results': [],
+                },
+            )
+            query_string = f'ordering={self.search_ordering}&search=test'
+            request_url = f'{reverse(self.view_name)}?{query_string}'
+            response = self.client.get(request_url)
+            self.assertEqual(response.status_code, 200)
+
+
+class ExportSecurityViewTestCaseMixin:
+    export_view_name = None
+    export_email_view_name = None
+    export_expected_xls_headers = None
+    export_expected_xls_rows = None
+
+    def test_export_some_data(self):
+        """
+        Test that the export view generates a spreadsheet with only the content returned
+        by the API.
+        """
+        expected_spreadsheet_content = [
+            self.export_expected_xls_headers,
+            *self.export_expected_xls_rows,
+        ]
+
+        with responses.RequestsMock() as rsps:
+            self.login(rsps=rsps)
+            sample_prison_list(rsps=rsps)
+            rsps.add(
+                rsps.GET,
+                api_url(self.api_list_path),
+                json={
+                    'count': 2,
+                    'results': self.get_api_object_list_response_data(),
+                }
+            )
+            response = self.client.get(reverse(self.export_view_name))
+
+        self.assertEqual(200, response.status_code)
+        self.assertEqual(
+            'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+            response['Content-Type'],
+        )
+        self.assertSpreadsheetEqual(response.content, expected_spreadsheet_content)
+
+    def test_email_export_some_data(self):
+        """
+        Test that the view sends the expected spreadsheet via email.
+        """
+        expected_spreadsheet_content = [
+            self.export_expected_xls_headers,
+            *self.export_expected_xls_rows,
+        ]
+
+        with responses.RequestsMock() as rsps:
+            self.login(rsps=rsps)
+            sample_prison_list(rsps=rsps)
+            rsps.add(
+                rsps.GET,
+                api_url(self.api_list_path),
+                json={
+                    'count': 2,
+                    'results': self.get_api_object_list_response_data(),
+                }
+            )
+            response = self.client.get(f'{reverse(self.export_email_view_name)}?ordering={self.search_ordering}')
+            self.assertRedirects(response, f'{reverse(self.view_name)}?ordering={self.search_ordering}')
+            self.assertSpreadsheetEqual(
+                mail.outbox[0].attachments[0][1],
+                expected_spreadsheet_content,
+                msg='Emailed contents do not match expected',
+            )
+
+    def test_export_no_data(self):
+        """
+        Test that the export view generates a spreadsheet without rows if the API call doesn't return any record.
+        """
+        expected_spreadsheet_content = [
+            self.export_expected_xls_headers,
+        ]
+
+        with responses.RequestsMock() as rsps:
+            self.login(rsps=rsps)
+            sample_prison_list(rsps=rsps)
+
+            rsps.add(
+                rsps.GET,
+                api_url(self.api_list_path),
+                json={
+                    'count': 0,
+                    'results': [],
+                },
+            )
+
+            response = self.client.get(reverse(self.export_view_name))
+
+        self.assertEqual(200, response.status_code)
+        self.assertEqual(
+            'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+            response['Content-Type'],
+        )
+        self.assertSpreadsheetEqual(response.content, expected_spreadsheet_content)
+
+    def test_email_export_no_data(self):
+        """
+        Test that the view sends the an empty spreadsheet via email.
+        """
+        expected_spreadsheet_content = [
+            self.export_expected_xls_headers,
+        ]
+
+        with responses.RequestsMock() as rsps:
+            self.login(rsps=rsps)
+            sample_prison_list(rsps=rsps)
+
+            rsps.add(
+                rsps.GET,
+                api_url(self.api_list_path),
+                json={
+                    'count': 0,
+                    'results': [],
+                },
+            )
+
+            response = self.client.get(f'{reverse(self.export_email_view_name)}?ordering={self.search_ordering}')
+            self.assertRedirects(response, f'{reverse(self.view_name)}?ordering={self.search_ordering}')
+            self.assertSpreadsheetEqual(
+                mail.outbox[0].attachments[0][1],
+                expected_spreadsheet_content,
+                msg='Emailed contents do not match expected',
+            )
+
+    def test_invalid_params_redirect_to_form(self):
+        """
+        Test that in case of invalid form, the export view redirects to the list page without
+        taking any action.
+        """
+        with responses.RequestsMock() as rsps:
+            self.login(rsps=rsps)
+            sample_prison_list(rsps=rsps)
+            response = self.client.get(f'{reverse(self.export_email_view_name)}?ordering=invalid')
+            self.assertRedirects(response, f'{reverse(self.view_name)}?ordering=invalid')
 
 
 class SenderViewsTestCase(SecurityViewTestCase):
@@ -658,16 +926,23 @@ class SenderViewsTestCase(SecurityViewTestCase):
         self.assertContains(response, 'non-field-error')
 
 
-class SenderViewsTestCaseV2(SecurityViewTestCase):
+class SenderViewsV2TestCase(
+    SimpleSearchV2SecurityTestCaseMixin,
+    ExportSecurityViewTestCaseMixin,
+    SecurityViewTestCase,
+):
     """
     Test case related to sender search V2 and detail views.
     """
     view_name = 'security:sender_list'
     search_results_view_name = 'security:sender_search_results'
     detail_view_name = 'security:sender_detail'
-    export_view_name = 'security:senders_export'
+    search_ordering = '-prisoner_count'
     api_list_path = '/senders/'
-    expected_xls_headers = [
+
+    export_view_name = 'security:senders_export'
+    export_email_view_name = 'security:senders_email_export'
+    export_expected_xls_headers = [
         'Sender name',
         'Payment source',
         'Credits sent',
@@ -683,158 +958,78 @@ class SenderViewsTestCaseV2(SecurityViewTestCase):
         'Other cardholder names',
         'Cardholder emails',
     ]
+    export_expected_xls_rows = [
+        [
+            'MAISIE NOLAN',
+            'Bank transfer',
+            4,
+            '£410.00',
+            3,
+            2,
+            '10-10-10',
+            '12312345',
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+        ],
+        [
+            'Maisie N',
+            'Debit card',
+            4,
+            '£420.00',
+            3,
+            2,
+            None,
+            None,
+            None,
+            '**** **** **** 1234',
+            '10/20',
+            'SW137NJ',
+            'Maisie Nolan',
+            'm@outside.local, mn@outside.local',
+        ]
+    ]
 
-    def get_user_data(
-        self,
-        *args,
-        flags=(
-            hmpps_employee_flag,
-            confirmed_prisons_flag,
-            SEARCH_V2_FLAG,
-        ),
-        **kwargs,
-    ):
-        """
-        Sets the SEARCH_V2_FLAG feature flag by default.
-        """
+    def get_api_object_list_response_data(self):
+        return [
+            self.bank_transfer_sender,
+            self.debit_card_sender,
+        ]
 
-        return super().get_user_data(*args, flags=flags, **kwargs)
-
-    @responses.activate
-    def test_default_prisons_used(self):
-        """
-        Test that the simple search template uses the prisons of the logged in user to
-        populate the `prison` hidden inputs.
-        The simple search filters by the user's prisons by default.
-        """
-        user_prisons = sample_prisons
-        user_data = self.get_user_data(prisons=user_prisons)
-
-        self.login(user_data=user_data)
-        no_saved_searches()
-        sample_prison_list()
-        response = self.client.get(reverse(self.view_name))
-        for prison in user_prisons:
-            self.assertContains(
-                response,
-                f'<input type="hidden" name="prison" value="{prison["nomis_id"]}" />',
-            )
-
-    @responses.activate
-    def test_displays_search_results(self):
-        """
-        Test that the search results page includes the objects returned by the API.
-        """
-        self.login()
-        no_saved_searches()
-        sample_prison_list()
-        responses.add(
-            responses.GET,
-            api_url(self.api_list_path),
-            json={
-                'count': 2,
-                'results': [self.bank_transfer_sender, self.debit_card_sender],
-            },
-        )
-        response = self.client.get(reverse(self.view_name))
+    def _test_simple_search_search_results_content(self, response):
         self.assertContains(response, '2 payment sources')
         self.assertContains(response, 'MAISIE NOLAN')
         response_content = response.content.decode(response.charset)
         self.assertIn('£410.00', response_content)
         self.assertIn('£420.00', response_content)
 
-    @responses.activate
-    def test_redirects_to_search_results_page(self):
-        """
-        Test that submitting the form redirects to the results page when the form is valid.
-        The action of submitting the form is represented by the query param
-        SIMPLE_SEARCH_FORM_SUBMITTED_INPUT_NAME which gets removed when redirecting.
-        """
-        self.login()
-        no_saved_searches()
-        sample_prison_list()
-        responses.add(
-            responses.GET,
-            api_url(self.api_list_path),
-            json={
-                'count': 2,
-                'results': [self.bank_transfer_sender, self.debit_card_sender],
-            },
-        )
-        query_string = 'ordering=-prisoner_count&search=test'
-        request_url = f'{reverse(self.view_name)}?{query_string}&{SIMPLE_SEARCH_FORM_SUBMITTED_INPUT_NAME}=1'
-        expected_redirect_url = f'{reverse(self.search_results_view_name)}?{query_string}'
-        response = self.client.get(request_url)
-        self.assertRedirects(
-            response,
-            expected_redirect_url,
-        )
+    def test_detail_view_displays_bank_transfer_detail(self):
+        sender_id = 9
+        with responses.RequestsMock() as rsps:
+            self.login(rsps=rsps)
+            rsps.add(
+                rsps.GET,
+                api_url(f'/senders/{sender_id}/'),
+                json=self.bank_transfer_sender,
+            )
+            rsps.add(
+                rsps.GET,
+                api_url(f'/senders/{sender_id}/credits/'),
+                json={
+                    'count': 4,
+                    'results': [self.credit_object] * 4,
+                },
+            )
 
-    @responses.activate
-    def test_doesnt_redirect_to_search_results_page_if_form_is_invalid(self):
-        """
-        Test that submitting the form doesn't redirect to the results page when the form is invalid.
-        The action of submitting the form is represented by the query param
-        SIMPLE_SEARCH_FORM_SUBMITTED_INPUT_NAME.
-        """
-        self.login()
-        no_saved_searches()
-        sample_prison_list()
-        responses.add(
-            responses.GET,
-            api_url(self.api_list_path),
-            json={
-                'count': 2,
-                'results': [self.bank_transfer_sender, self.debit_card_sender],
-            },
-        )
-        query_string = 'ordering=invalid&search=test'
-        request_url = f'{reverse(self.view_name)}?{query_string}&{SIMPLE_SEARCH_FORM_SUBMITTED_INPUT_NAME}=1'
-        response = self.client.get(request_url)
-        self.assertEqual(response.status_code, 200)
-
-    @responses.activate
-    def test_navigating_back_to_simple_search_form(self):
-        """
-        Test that going back to the simple search form doesn't redirect to the results page.
-        The action of NOT submitting the form explicitly is represented by the absence of query param
-        SIMPLE_SEARCH_FORM_SUBMITTED_INPUT_NAME.
-        """
-        self.login()
-        no_saved_searches()
-        sample_prison_list()
-        responses.add(
-            responses.GET,
-            api_url(self.api_list_path),
-            json={
-                'count': 2,
-                'results': [self.bank_transfer_sender, self.debit_card_sender],
-            },
-        )
-        query_string = 'ordering=-prisoner_count&search=test'
-        request_url = f'{reverse(self.view_name)}?{query_string}'
-        response = self.client.get(request_url)
-        self.assertEqual(response.status_code, 200)
-
-    @responses.activate
-    def test_displays_bank_transfer_detail(self):
-        self.login()
-        no_saved_searches()
-        responses.add(
-            responses.GET,
-            api_url('/senders/{id}/'.format(id=9)),
-            json=self.bank_transfer_sender
-        )
-        responses.add(
-            responses.GET,
-            api_url('/senders/{id}/credits/'.format(id=9)),
-            json={
-                'count': 4,
-                'results': [self.credit_object, self.credit_object, self.credit_object, self.credit_object],
-            }
-        )
-
-        response = self.client.get(reverse(self.detail_view_name, kwargs={'sender_id': 9}))
+            response = self.client.get(
+                reverse(
+                    self.detail_view_name,
+                    kwargs={'sender_id': sender_id},
+                ),
+            )
         self.assertEqual(response.status_code, 200)
         response_content = response.content.decode(response.charset)
         self.assertIn('MAISIE', response_content)
@@ -842,24 +1037,29 @@ class SenderViewsTestCaseV2(SecurityViewTestCase):
         self.assertIn('JAMES HALLS', response_content)
         self.assertIn('£102.50', response_content)
 
-    @responses.activate
-    def test_displays_debit_card_detail(self):
-        self.login()
-        no_saved_searches()
-        responses.add(
-            responses.GET,
-            api_url('/senders/{id}/'.format(id=9)),
-            json=self.debit_card_sender
-        )
-        responses.add(
-            responses.GET,
-            api_url('/senders/{id}/credits/'.format(id=9)),
-            json={
-                'count': 4,
-                'results': [self.credit_object, self.credit_object, self.credit_object, self.credit_object],
-            }
-        )
-        response = self.client.get(reverse(self.detail_view_name, kwargs={'sender_id': 9}))
+    def test_detail_view_displays_debit_card_detail(self):
+        sender_id = 9
+        with responses.RequestsMock() as rsps:
+            self.login(rsps=rsps)
+            rsps.add(
+                rsps.GET,
+                api_url(f'/senders/{sender_id}/'),
+                json=self.debit_card_sender,
+            )
+            rsps.add(
+                rsps.GET,
+                api_url(f'/senders/{sender_id}/credits/'),
+                json={
+                    'count': 4,
+                    'results': [self.credit_object] * 4,
+                }
+            )
+            response = self.client.get(
+                reverse(
+                    self.detail_view_name,
+                    kwargs={'sender_id': sender_id},
+                ),
+            )
         self.assertEqual(response.status_code, 200)
         response_content = response.content.decode(response.charset)
         self.assertIn('**** **** **** 1234', response_content)
@@ -868,137 +1068,58 @@ class SenderViewsTestCaseV2(SecurityViewTestCase):
         self.assertIn('JAMES HALLS', response_content)
         self.assertIn('£102.50', response_content)
 
-    @responses.activate
     def test_detail_not_found(self):
-        self.login()
-        no_saved_searches()
-        responses.add(
-            responses.GET,
-            api_url('/senders/{id}/'.format(id=9)),
-            status=404
-        )
-        responses.add(
-            responses.GET,
-            api_url('/senders/{id}/credits/'.format(id=9)),
-            status=404
-        )
-        with silence_logger('django.request'):
-            response = self.client.get(reverse(self.detail_view_name, kwargs={'sender_id': 9}))
+        sender_id = 9
+        with responses.RequestsMock() as rsps:
+            self.login(rsps=rsps)
+            rsps.add(
+                rsps.GET,
+                api_url(f'/senders/{sender_id}/'),
+                status=404,
+            )
+            with silence_logger('django.request'):
+                response = self.client.get(
+                    reverse(
+                        self.detail_view_name,
+                        kwargs={'sender_id': sender_id},
+                    ),
+                )
         self.assertEqual(response.status_code, 404)
 
-    @responses.activate
     def test_connection_errors(self):
-        self.login()
-        no_saved_searches()
-        sample_prison_list()
-        responses.add(
-            responses.GET,
-            api_url('/senders/{id}/'.format(id=9)),
-            status=500
-        )
-        with silence_logger('django.request'):
-            response = self.client.get(reverse(self.view_name))
+        sender_id = 9
+        with responses.RequestsMock() as rsps:
+            self.login(rsps=rsps)
+            sample_prison_list(rsps=rsps)
+            rsps.add(
+                rsps.GET,
+                api_url(self.api_list_path),
+                status=500,
+            )
+            with silence_logger('django.request'):
+                response = self.client.get(reverse(self.view_name))
         self.assertContains(response, 'non-field-error')
 
-        no_saved_searches()
-        responses.add(
-            responses.GET,
-            api_url('/senders/{id}/'.format(id=9)),
-            status=500
-        )
-        responses.add(
-            responses.GET,
-            api_url('/senders/{id}/credits/'.format(id=9)),
-            status=500
-        )
-        with silence_logger('django.request'):
-            response = self.client.get(reverse(self.detail_view_name, kwargs={'sender_id': 9}))
+        with responses.RequestsMock() as rsps:
+            no_saved_searches(rsps=rsps)
+            rsps.add(
+                rsps.GET,
+                api_url(f'/senders/{sender_id}/'),
+                status=500,
+            )
+            rsps.add(
+                rsps.GET,
+                api_url(f'/senders/{sender_id}/credits/'),
+                status=500,
+            )
+            with silence_logger('django.request'):
+                response = self.client.get(
+                    reverse(
+                        self.detail_view_name,
+                        kwargs={'sender_id': sender_id},
+                    ),
+                )
         self.assertContains(response, 'non-field-error')
-
-    @responses.activate
-    def test_export_some_data(self):
-        """
-        Test that the export view generates a spreadsheet with only the content returned
-        by the API.
-        """
-        expected_spreadsheet_content = [
-            self.expected_xls_headers,
-            [
-                'MAISIE NOLAN',
-                'Bank transfer',
-                4,
-                '£410.00',
-                3,
-                2,
-                '10-10-10',
-                '12312345',
-                None,
-                None,
-                None,
-                None,
-                None,
-                None,
-            ],
-            [
-                'Maisie N',
-                'Debit card',
-                4,
-                '£420.00',
-                3,
-                2,
-                None,
-                None,
-                None,
-                '**** **** **** 1234',
-                '10/20',
-                'SW137NJ',
-                'Maisie Nolan',
-                'm@outside.local, mn@outside.local',
-            ],
-        ]
-
-        self.login()
-        no_saved_searches()
-        sample_prison_list()
-        responses.add(
-            responses.GET,
-            api_url(self.api_list_path),
-            json={
-                'count': 2,
-                'results': [self.bank_transfer_sender, self.debit_card_sender],
-            }
-        )
-        response = self.client.get(reverse(self.export_view_name))
-
-        self.assertEqual(200, response.status_code)
-        self.assertEqual('application/vnd.openxmlformats-officedocument.spreadsheetml.sheet', response['Content-Type'])
-        self.assertSpreadsheetEqual(response.content, expected_spreadsheet_content)
-
-    @responses.activate
-    def test_export_no_data(self):
-        """
-        Test that the export view generates a spreadsheet without rows if the API call doesn't return any record.
-        """
-        expected_spreadsheet_content = [
-            self.expected_xls_headers,
-        ]
-
-        self.login()
-        no_saved_searches()
-        sample_prison_list()
-        responses.add(
-            responses.GET,
-            api_url(self.api_list_path),
-            json={
-                'count': 0,
-                'results': [],
-            }
-        )
-        response = self.client.get(reverse(self.export_view_name))
-
-        self.assertEqual(200, response.status_code)
-        self.assertEqual('application/vnd.openxmlformats-officedocument.spreadsheetml.sheet', response['Content-Type'])
-        self.assertSpreadsheetEqual(response.content, expected_spreadsheet_content)
 
 
 class PrisonerListTestCase(SecurityViewTestCase):
@@ -1101,7 +1222,10 @@ class PrisonerListTestCase(SecurityViewTestCase):
         self.assertContains(response, 'non-field-error')
 
 
-class CreditsListTestCase(SecurityViewTestCase):
+class CreditViewsTestCase(SecurityViewTestCase):
+    """
+    TODO: delete after search V2 goes live.
+    """
     view_name = 'security:credit_list'
     detail_view_name = 'security:credit_detail'
     api_list_path = '/credits/'
@@ -1210,6 +1334,235 @@ class CreditsListTestCase(SecurityViewTestCase):
         self.assertIn('21-96-57', response_content)
         self.assertIn('88447894', response_content)
         self.assertIn('Credited by Maria', response_content)
+
+
+class CreditViewsV2TestCase(SimpleSearchV2SecurityTestCaseMixin, ExportSecurityViewTestCaseMixin, SecurityViewTestCase):
+    """
+    Test case related to credit search V2 and detail views.
+    """
+    view_name = 'security:credit_list'
+    search_results_view_name = 'security:credit_search_results'
+    detail_view_name = 'security:credit_detail'
+    search_ordering = '-received_at'
+    api_list_path = '/credits/'
+
+    debit_card_credit = {
+        'id': 1,
+        'source': 'online',
+        'amount': 23000,
+        'intended_recipient': 'Mr G Melley',
+        'prisoner_number': 'A1411AE',
+        'prisoner_name': 'GEORGE MELLEY',
+        'prison': 'LEI',
+        'prison_name': 'HMP LEEDS',
+        'sender_name': None,
+        'sender_sort_code': None,
+        'sender_account_number': None,
+        'sender_email': 'ian@mail.local',
+        'billing_address': {'line1': '102PF', 'city': 'London'},
+        'sender_roll_number': None,
+        'card_number_last_digits': '4444',
+        'card_expiry_date': '07/18',
+        'resolution': 'credited',
+        'owner': None,
+        'owner_name': 'Maria',
+        'received_at': '2016-05-25T20:24:00Z',
+        'credited_at': '2016-05-25T20:27:00Z',
+        'refunded_at': None,
+        'comments': [{'user_full_name': 'Eve', 'comment': 'OK'}],
+        'nomis_transaction_id': None,
+        'ip_address': '127.0.0.1',
+    }
+    bank_transfer_credit = {
+        'id': 2,
+        'source': 'bank_transfer',
+        'amount': 27500,
+        'intended_recipient': None,
+        'prisoner_number': 'A1413AE',
+        'prisoner_name': 'NORMAN STANLEY FLETCHER',
+        'prison': 'LEI',
+        'prison_name': 'HMP LEEDS',
+        'sender_name': 'HEIDENREICH X',
+        'sender_email': None,
+        'billing_address': None,
+        'sender_sort_code': '219657',
+        'sender_account_number': '88447894',
+        'card_number_last_digits': None,
+        'card_expiry_date': None,
+        'sender_roll_number': '',
+        'resolution': 'credited',
+        'owner': None,
+        'owner_name': 'Maria',
+        'received_at': '2016-05-22T23:00:00Z',
+        'credited_at': '2016-05-23T01:10:00Z',
+        'refunded_at': None,
+        'comments': [],
+        'nomis_transaction_id': '123456-7',
+        'ip_address': '127.0.0.1',
+    }
+
+    export_view_name = 'security:credits_export'
+    export_email_view_name = 'security:credits_email_export'
+    export_expected_xls_headers = [
+        'Prisoner name',
+        'Prisoner number',
+        'Prison',
+        'Sender name',
+        'Payment method',
+        'Bank transfer sort code',
+        'Bank transfer account',
+        'Bank transfer roll number',
+        'Debit card number',
+        'Debit card expiry',
+        'Address',
+        'Amount',
+        'Date received',
+        'Credited status',
+        'Date credited',
+        'NOMIS ID',
+        'IP',
+    ]
+    export_expected_xls_rows = [
+        [
+            'GEORGE MELLEY',
+            'A1411AE',
+            'HMP LEEDS',
+            None,
+            'Debit card',
+            None,
+            None,
+            None,
+            '**** **** **** 4444',
+            '07/18',
+            '102PF, London',
+            '£230.00',
+            '2016-05-25 21:24:00',
+            'Credited',
+            '2016-05-25 21:27:00',
+            None,
+            '127.0.0.1',
+            'ian@mail.local'
+        ],
+        [
+            'NORMAN STANLEY FLETCHER',
+            'A1413AE',
+            'HMP LEEDS',
+            'HEIDENREICH X',
+            'Bank transfer',
+            '21-96-57',
+            '88447894',
+            None,
+            None,
+            None,
+            None,
+            '£275.00',
+            '2016-05-23 00:00:00',
+            'Credited',
+            '2016-05-23 02:10:00',
+            '123456-7',
+            '127.0.0.1',
+            None
+        ],
+    ]
+
+    def _test_simple_search_search_results_content(self, response):
+        self.assertContains(response, '2 credits')
+        self.assertContains(response, 'GEORGE MELLEY')
+        response_content = response.content.decode(response.charset)
+        self.assertIn('A1413AE', response_content)
+        self.assertIn('275.00', response_content)
+        self.assertIn('Bank transfer', response_content)
+        self.assertIn('Debit card', response_content)
+
+    def test_detail_view_displays_debit_card_detail(self):
+        credit_id = 2
+        with responses.RequestsMock() as rsps:
+            rsps.add(
+                rsps.GET,
+                f'{api_url(self.api_list_path)}?pk={credit_id}',
+                json={
+                    'count': 1,
+                    'previous': None,
+                    'next': None,
+                    'results': [self.debit_card_credit],
+                }
+            )
+
+            self.login(rsps=rsps)
+            response = self.client.get(
+                reverse(
+                    self.detail_view_name,
+                    kwargs={'credit_id': credit_id},
+                ),
+            )
+        self.assertContains(response, 'Debit card')
+        response_content = response.content.decode(response.charset)
+        self.assertIn('£230.00', response_content)
+        self.assertIn('GEORGE MELLEY', response_content)
+        self.assertIn('Mr G Melley', response_content)
+        self.assertIn('A1411AE', response_content)
+        self.assertIn('Credited by Maria', response_content)
+        self.assertIn('Eve', response_content)
+        self.assertIn('OK', response_content)
+
+    def test_detail_view_displays_bank_transfer_detail(self):
+        credit_id = 2
+        with responses.RequestsMock() as rsps:
+            rsps.add(
+                rsps.GET,
+                f'{api_url(self.api_list_path)}?pk={credit_id}',
+                json={
+                    'count': 1,
+                    'previous': None,
+                    'next': None,
+                    'results': [self.bank_transfer_credit],
+                }
+            )
+
+            self.login(rsps=rsps)
+            response = self.client.get(
+                reverse(
+                    self.detail_view_name,
+                    kwargs={'credit_id': credit_id},
+                ),
+            )
+        self.assertContains(response, 'Bank transfer')
+        response_content = response.content.decode(response.charset)
+        self.assertIn('£275.00', response_content)
+        self.assertIn('NORMAN STANLEY FLETCHER', response_content)
+        self.assertIn('21-96-57', response_content)
+        self.assertIn('88447894', response_content)
+        self.assertIn('Credited by Maria', response_content)
+
+    def test_detail_not_found(self):
+        credit_id = 999
+        with responses.RequestsMock() as rsps:
+            rsps.add(
+                rsps.GET,
+                f'{api_url(self.api_list_path)}?pk={credit_id}',
+                json={
+                    'count': 0,
+                    'previous': None,
+                    'next': None,
+                    'results': [],
+                }
+            )
+
+            self.login(rsps=rsps)
+            with silence_logger('django.request'):
+                response = self.client.get(
+                    reverse(
+                        self.detail_view_name,
+                        kwargs={'credit_id': credit_id},
+                    ),
+                )
+        self.assertEqual(response.status_code, 404)
+
+    def get_api_object_list_response_data(self):
+        return [
+            self.debit_card_credit,
+            self.bank_transfer_credit,
+        ]
 
 
 class DisbursementsListTestCase(SecurityViewTestCase):
@@ -1346,150 +1699,6 @@ def temp_spreadsheet(data):
         wb = load_workbook(f)
         ws = wb.active
         yield ws
-
-
-class CreditsExportTestCase(SecurityBaseTestCase):
-    expected_headers = [
-        'Prisoner name', 'Prisoner number', 'Prison', 'Sender name', 'Payment method',
-        'Bank transfer sort code', 'Bank transfer account', 'Bank transfer roll number',
-        'Debit card number', 'Debit card expiry', 'Address', 'Amount', 'Date received',
-        'Credited status', 'Date credited', 'NOMIS ID', 'IP'
-    ]
-
-    @responses.activate
-    def test_creates_xslx(self):
-        response_data = {
-            'count': 2,
-            'previous': None,
-            'next': None,
-            'results': [
-                {
-                    'id': 1,
-                    'source': 'online',
-                    'amount': 23000,
-                    'intended_recipient': 'GEORGE MELLEY',
-                    'prisoner_number': 'A1411AE', 'prisoner_name': 'GEORGE MELLEY',
-                    'prison': 'LEI', 'prison_name': 'HMP LEEDS',
-                    'sender_name': None,
-                    'sender_sort_code': None, 'sender_account_number': None, 'sender_roll_number': None,
-                    'card_number_last_digits': None, 'card_expiry_date': None,
-                    'billing_address': {'line1': '102PF', 'city': 'London'},
-                    'ip_address': '127.0.0.1', 'sender_email': 'ian@mail.local',
-                    'resolution': 'credited', 'nomis_transaction_id': None,
-                    'owner': None, 'owner_name': None,
-                    'received_at': '2016-05-25T20:24:00Z',
-                    'credited_at': '2016-05-25T20:27:00Z', 'refunded_at': None,
-                },
-                {
-                    'id': 2,
-                    'source': 'bank_transfer',
-                    'amount': 27500,
-                    'intended_recipient': None,
-                    'prisoner_number': 'A1413AE', 'prisoner_name': 'NORMAN STANLEY FLETCHER',
-                    'prison': 'LEI', 'prison_name': 'HMP LEEDS',
-                    'sender_name': 'HEIDENREICH X',
-                    'sender_sort_code': '219657', 'sender_account_number': '88447894',
-                    'sender_roll_number': '', 'sender_email': None,
-                    'card_number_last_digits': None, 'card_expiry_date': None,
-                    'billing_address': None, 'ip_address': '127.0.0.1',
-                    'resolution': 'credited', 'nomis_transaction_id': '123456-7',
-                    'owner': None, 'owner_name': None,
-                    'received_at': '2016-05-22T23:00:00Z',
-                    'credited_at': '2016-05-23T01:10:00Z', 'refunded_at': None,
-                },
-            ]
-        }
-        sample_prison_list()
-        responses.add(
-            responses.GET,
-            api_url('/credits/'),
-            json=response_data
-        )
-
-        expected_values = [
-            self.expected_headers,
-            ['GEORGE MELLEY', 'A1411AE', 'HMP LEEDS', None, 'Debit card', None, None, None,
-             None, None, '102PF, London', '£230.00', '2016-05-25 21:24:00',
-             'Credited', '2016-05-25 21:27:00', None, '127.0.0.1', 'ian@mail.local'],
-            ['NORMAN STANLEY FLETCHER', 'A1413AE', 'HMP LEEDS', 'HEIDENREICH X',
-             'Bank transfer', '21-96-57', '88447894', None, None, None, None,
-             '£275.00', '2016-05-23 00:00:00',
-             'Credited', '2016-05-23 02:10:00', '123456-7', '127.0.0.1', None]
-        ]
-
-        self.login()
-        response = self.client.get(reverse('security:credits_export'))
-        self.assertEqual(200, response.status_code)
-        self.assertEqual('application/vnd.openxmlformats-officedocument.spreadsheetml.sheet', response['Content-Type'])
-
-        self.assertSpreadsheetEqual(response.content, expected_values)
-
-        no_saved_searches()
-        responses.add(
-            responses.GET,
-            api_url('/credits/'),
-            json=response_data
-        )
-        response = self.client.get(
-            f"{reverse('security:credits_email_export')}?ordering=-received_at",
-            follow=False,
-        )
-        self.assertRedirects(response, f"{reverse('security:credit_list')}?ordering=-received_at")
-        self.assertSpreadsheetEqual(
-            mail.outbox[0].attachments[0][1],
-            expected_values,
-            msg='Emailed contents do not match expected'
-        )
-
-    @responses.activate
-    def test_no_data(self):
-        sample_prison_list()
-        response_data = {
-            'count': 0,
-            'previous': None,
-            'next': None,
-            'results': []
-        }
-        responses.add(
-            responses.GET,
-            api_url('/credits/'),
-            json=response_data
-        )
-
-        expected_values = [self.expected_headers]
-
-        self.login()
-        response = self.client.get(reverse('security:credits_export'))
-        self.assertEqual(200, response.status_code)
-        self.assertEqual('application/vnd.openxmlformats-officedocument.spreadsheetml.sheet', response['Content-Type'])
-
-        self.assertSpreadsheetEqual(response.content, expected_values)
-
-        no_saved_searches()
-        responses.add(
-            responses.GET,
-            api_url('/credits/'),
-            json=response_data
-        )
-        response = self.client.get(
-            f"{reverse('security:credits_email_export')}?ordering=-received_at",
-            follow=False,
-        )
-        self.assertRedirects(response, f"{reverse('security:credit_list')}?ordering=-received_at")
-        self.assertSpreadsheetEqual(
-            mail.outbox[0].attachments[0][1],
-            expected_values,
-            msg='Emailed contents do not match expected'
-        )
-
-    @responses.activate
-    def test_invalid_params_redirects_to_form(self):
-        sample_prison_list()
-        self.login()
-        response = self.client.get(
-            f"{reverse('security:credits_export')}?received_at__gte=LL"
-        )
-        self.assertRedirects(response, f"{reverse('security:credit_list')}?received_at__gte=LL")
 
 
 class PinnedProfileTestCase(SecurityViewTestCase):

--- a/mtp_noms_ops/apps/security/tests/test_views.py
+++ b/mtp_noms_ops/apps/security/tests/test_views.py
@@ -541,6 +541,9 @@ class SecurityViewTestCase(SecurityBaseTestCase):
 class SimpleSearchV2SecurityTestCaseMixin:
     search_results_view_name = None
 
+    # TODO: delete when all forms start using `simple_search` instead of `search`
+    search_form_input_name = 'simple_search'
+
     def get_user_data(
         self,
         *args,
@@ -618,7 +621,7 @@ class SimpleSearchV2SecurityTestCaseMixin:
                     'results': [],
                 },
             )
-            query_string = f'ordering={self.search_ordering}&search=test'
+            query_string = f'ordering={self.search_ordering}&{self.search_form_input_name}=test'
             request_url = f'{reverse(self.view_name)}?{query_string}&{SIMPLE_SEARCH_FORM_SUBMITTED_INPUT_NAME}=1'
             expected_redirect_url = f'{reverse(self.search_results_view_name)}?{query_string}'
             response = self.client.get(request_url)
@@ -636,7 +639,7 @@ class SimpleSearchV2SecurityTestCaseMixin:
         with responses.RequestsMock() as rsps:
             self.login(rsps=rsps)
             sample_prison_list(rsps=rsps)
-            query_string = 'ordering=invalid&search=test'
+            query_string = 'ordering=invalid&{self.search_form_input_name}=test'
             request_url = f'{reverse(self.view_name)}?{query_string}&{SIMPLE_SEARCH_FORM_SUBMITTED_INPUT_NAME}=1'
             response = self.client.get(request_url)
             self.assertEqual(response.status_code, 200)
@@ -658,7 +661,7 @@ class SimpleSearchV2SecurityTestCaseMixin:
                     'results': [],
                 },
             )
-            query_string = f'ordering={self.search_ordering}&search=test'
+            query_string = f'ordering={self.search_ordering}&{self.search_form_input_name}=test'
             request_url = f'{reverse(self.view_name)}?{query_string}'
             response = self.client.get(request_url)
             self.assertEqual(response.status_code, 200)
@@ -938,6 +941,7 @@ class SenderViewsV2TestCase(
     search_results_view_name = 'security:sender_search_results'
     detail_view_name = 'security:sender_detail'
     search_ordering = '-prisoner_count'
+    search_form_input_name = 'search'
     api_list_path = '/senders/'
 
     export_view_name = 'security:senders_export'

--- a/mtp_noms_ops/apps/security/urls.py
+++ b/mtp_noms_ops/apps/security/urls.py
@@ -55,15 +55,22 @@ urlpatterns = [
         security_test(
             search_v2_view_dispatcher(
                 views.CreditListView.as_view(),
-                views.CreditListView.as_view(),
+                views.CreditListViewV2.as_view(
+                    view_type=views.ViewType.simple_search_form,
+                ),
             ),
         ),
         name='credit_list',
     ),
     url(
-        r'^credits/(?P<credit_id>\d+)/$',
-        security_test(views.CreditDetailView.as_view()),
-        name='credit_detail',
+        r'^credits/search-results/$',
+        security_test(
+            views.CreditListViewV2.as_view(
+                view_type=views.ViewType.search_results,
+                referral_view='security:credit_list',
+            ),
+        ),
+        name='credit_search_results',
     ),
     url(
         r'^credits/export/$',
@@ -73,7 +80,7 @@ urlpatterns = [
                     view_type=views.ViewType.export_download,
                     referral_view='security:credit_list',
                 ),
-                views.CreditListView.as_view(
+                views.CreditListViewV2.as_view(
                     view_type=views.ViewType.export_download,
                     referral_view='security:credit_list',
                 ),
@@ -89,13 +96,18 @@ urlpatterns = [
                     view_type=views.ViewType.export_email,
                     referral_view='security:credit_list',
                 ),
-                views.CreditListView.as_view(
+                views.CreditListViewV2.as_view(
                     view_type=views.ViewType.export_email,
                     referral_view='security:credit_list',
                 ),
             ),
         ),
         name='credits_email_export',
+    ),
+    url(
+        r'^credits/(?P<credit_id>\d+)/$',
+        security_test(views.CreditDetailView.as_view()),
+        name='credit_detail',
     ),
 
     # senders

--- a/mtp_noms_ops/apps/security/views/__init__.py
+++ b/mtp_noms_ops/apps/security/views/__init__.py
@@ -10,6 +10,7 @@ from .object_list import (  # noqa: F401
     SenderListViewV2,
     PrisonerListView,
     CreditListView,
+    CreditListViewV2,
     DisbursementListView,
 )
 from .review import ReviewCreditsView  # noqa: F401

--- a/mtp_noms_ops/apps/security/views/object_base.py
+++ b/mtp_noms_ops/apps/security/views/object_base.py
@@ -93,6 +93,7 @@ class SecurityView(FormView):
     view_type = None
     referral_view = None
     search_results_view = None
+    simple_search_view = None
     export_download_limit = settings.MAX_CREDITS_TO_DOWNLOAD
     export_email_limit = settings.MAX_CREDITS_TO_EMAIL
     object_name = None
@@ -175,7 +176,7 @@ class SecurityView(FormView):
         if self.view_type == ViewType.search_results:
             breadcrumbs = [
                 {'name': _('Home'), 'url': reverse('security:dashboard')},
-                {'name': self.title, 'url': f'{reverse("security:sender_list")}?{kwargs["form"].query_string}'},
+                {'name': self.title, 'url': f'{reverse(self.simple_search_view)}?{kwargs["form"].query_string}'},
                 {'name': _('Search results')}
             ]
         else:

--- a/mtp_noms_ops/apps/security/views/object_list.py
+++ b/mtp_noms_ops/apps/security/views/object_list.py
@@ -5,7 +5,9 @@ from security.forms.object_list import (
     SendersForm,
     SendersFormV2,
     PrisonersForm,
-    CreditsForm, DisbursementsForm,
+    CreditsForm,
+    CreditsFormV2,
+    DisbursementsForm,
 )
 from security.views.object_base import SecurityView
 
@@ -19,6 +21,20 @@ class CreditListView(SecurityView):
     template_name = 'security/credits.html'
     form_class = CreditsForm
     object_list_context_key = 'credits'
+
+
+class CreditListViewV2(SecurityView):
+    """
+    Credit list/search view V2
+    """
+    title = _('Credits')
+    form_class = CreditsFormV2
+    template_name = 'security/credits_list.html'
+    search_results_view = 'security:credit_search_results'
+    simple_search_view = 'security:credit_list'
+    object_list_context_key = 'credits'
+    object_name = _('credit')
+    object_name_plural = _('credits')
 
 
 class DisbursementListView(SecurityView):
@@ -56,6 +72,7 @@ class SenderListViewV2(SecurityView):
     form_class = SendersFormV2
     template_name = 'security/senders_list.html'
     search_results_view = 'security:sender_search_results'
+    simple_search_view = 'security:sender_list'
     object_list_context_key = 'senders'
     object_name = _('payment source')
     object_name_plural = _('payment sources')

--- a/mtp_noms_ops/assets-src/stylesheets/app.scss
+++ b/mtp_noms_ops/assets-src/stylesheets/app.scss
@@ -83,3 +83,25 @@ form .form-group .form-hint {
     }
   }
 }
+
+
+.mtp-with-spaced-header {
+  #content {
+    margin-top: 55px;
+
+    @include media(mobile) {
+      margin-top: 35px;
+    }
+  }
+
+  header{
+    .heading-xlarge {
+      margin-top: 0;
+      margin-bottom: 50px;
+
+      @include media(mobile) {
+        margin-bottom: 30px;
+      }
+    }
+  }
+}

--- a/mtp_noms_ops/assets-src/stylesheets/views/_security-form-fields.scss
+++ b/mtp_noms_ops/assets-src/stylesheets/views/_security-form-fields.scss
@@ -117,7 +117,7 @@ select[disabled] {
 }
 
 .mtp-security-form--simple {
-  #id_search-label {
+  #id_simple_search-label, #id_search-label {
     font-size: 27px;
 
     @include media(mobile) {
@@ -125,11 +125,11 @@ select[disabled] {
     }
   }
 
-  #id_search {
+  #id_simple_search, #id_search {
     width: 100%;
   }
 
-  #id_search-hint {
+  #id_simple_search-hint, #id_search-hint {
     margin-bottom: 10px;
 
     @include media(mobile) {

--- a/mtp_noms_ops/assets-src/stylesheets/views/_security-form-fields.scss
+++ b/mtp_noms_ops/assets-src/stylesheets/views/_security-form-fields.scss
@@ -119,6 +119,10 @@ select[disabled] {
 .mtp-security-form--simple {
   #id_search-label {
     font-size: 27px;
+
+    @include media(mobile) {
+      font-size: 18px;
+    }
   }
 
   #id_search {
@@ -127,5 +131,9 @@ select[disabled] {
 
   #id_search-hint {
     margin-bottom: 10px;
+
+    @include media(mobile) {
+      margin-top: 5px;
+    }
   }
 }

--- a/mtp_noms_ops/templates/base.html
+++ b/mtp_noms_ops/templates/base.html
@@ -21,7 +21,7 @@
           {% if request.can_pre_approve %}
             {% include 'proposition-tab.html' with view_name='security:review_credits' subview_names='security:review_credits' link_text=_('New credits check') %}
           {% endif %}
-          {% include 'proposition-tab.html' with view_name='security:credit_list' subview_names='security:credit_list security:credit_detail' link_text=_('Credits') params=initial_params %}
+          {% include 'proposition-tab.html' with view_name='security:credit_list' subview_names='security:credit_list security:credit_detail security:credit_search_results' link_text=_('Credits') params=initial_params %}
           {% include 'proposition-tab.html' with view_name='security:sender_list' subview_names='security:sender_list security:sender_detail security:sender_search_results' link_text=_('Payment sources') params=initial_params hide_on_mobile=True %}
           {% include 'proposition-tab.html' with view_name='security:prisoner_list' subview_names='security:prisoner_list security:prisoner_detail security:prisoner_disbursement_detail' link_text=_('Prisoners') params=initial_params hide_on_mobile=True %}
           {% include 'proposition-tab.html' with view_name='security:disbursement_list' subview_names='security:disbursement_list security:disbursement_detail' link_text=_('Disbursements') params=initial_params %}

--- a/mtp_noms_ops/templates/security/credits_list.html
+++ b/mtp_noms_ops/templates/security/credits_list.html
@@ -18,7 +18,7 @@
 
     <div class="grid-row">
         <div class="column-two-thirds">
-          {% include 'security/forms/top-area-object-list.html' %}
+          {% include 'security/forms/top-area-object-list.html' with field=form.simple_search %}
         </div>
     </div>
 

--- a/mtp_noms_ops/templates/security/credits_list.html
+++ b/mtp_noms_ops/templates/security/credits_list.html
@@ -1,0 +1,71 @@
+{% extends 'base.html' %}
+{% load i18n %}
+{% load mtp_common %}
+{% load security %}
+
+{% block page_title %}{{ view.title }} – {{ block.super }}{% endblock %}
+
+{% block phase_banner %}
+  {{ block.super }}
+  {% include "security/forms/prison-switcher.html" %}
+{% endblock %}
+
+{% comment %}TODO: Move body_classes block to base.html when search V2 goes live to make all the existing pages consistent.{% endcomment %}
+{% block body_classes %}{{ block.super }} mtp-with-spaced-header{% endblock body_classes %}
+
+{% block inner_content %}
+  <form id="filter-credits" class="mtp-security-search js-FormAnalytics" method="get">
+
+    <div class="grid-row">
+        <div class="column-two-thirds">
+          {% include 'security/forms/top-area-object-list.html' %}
+        </div>
+    </div>
+
+    {% if form.is_valid %}
+      <div class="mtp-results-list">
+        <div class="print-hidden mtp-links--no-panel">
+          <a class="js-print-trigger js-FormAnalytics-click" href="#print-dialog" data-click-track="print-{{ view.get_class_name }},{{ view.get_used_request_params|join:'&' }}">{% trans 'Print' %}</a>
+          &nbsp;
+          {% url 'security:credits_export' as export_view %}
+          {% url 'security:credits_email_export' as email_export_view %}
+          {% include 'security/includes/export-dialogue.html' with export_message=_('There are too many credits to download.') %}
+        </div>
+
+        <table class="mtp-table">
+          <caption class="visually-hidden">{{ form.search_description.description }}</caption>
+          <thead>
+            <tr>
+              {% include 'security/includes/credit-header-row.html' with link_prisoner=True %}
+            </tr>
+          </thead>
+          <tbody>
+            {% for credit in credits %}
+              <tr>
+                {% include 'security/includes/credit-row.html' with link_prisoner=True link_sender=True %}
+              </tr>
+            {% empty %}
+              <tr>
+                <td colspan="7">{% trans 'No matching credits found' %}</td>
+              </tr>
+            {% endfor %}
+          </tbody>
+        </table>
+      </div>
+
+      <div class="mtp-page-list-container">
+        {% page_list page=form.cleaned_data.page page_count=form.page_count query_string=form.query_string %}
+
+        <p class="mtp-object-count">
+          {% blocktrans trimmed count count=form.total_count with number=form.total_count|separate_thousands %}
+            {{ number }} credit
+          {% plural %}
+            {{ number }} credits
+          {% endblocktrans %}
+        </p>
+      </div>
+    {% endif %}
+
+  </form>
+
+{% endblock %}

--- a/mtp_noms_ops/templates/security/forms/top-area-object-list.html
+++ b/mtp_noms_ops/templates/security/forms/top-area-object-list.html
@@ -30,7 +30,7 @@
         <input type="hidden" name="prison" value="{{ prison.nomis_id }}" />
     {% endfor %}
 
-    {% with field=form.search %}
+    {% with field=field %}
       <div id="{{ field.id_for_label }}-wrapper" class="form-group {% if field.errors %}form-group-error{% endif %}">
         {% include 'mtp_common/forms/field-label.html' with field=field only %}
         {% include 'mtp_common/forms/field-errors.html' with field=field only %}

--- a/mtp_noms_ops/templates/security/senders_list.html
+++ b/mtp_noms_ops/templates/security/senders_list.html
@@ -18,7 +18,7 @@
 
     <div class="grid-row">
         <div class="column-two-thirds">
-          {% include 'security/forms/top-area-object-list.html' %}
+          {% include 'security/forms/top-area-object-list.html' with field=form.search %}
         </div>
 
         <div class="column-one-third print-hidden">

--- a/mtp_noms_ops/templates/security/senders_list.html
+++ b/mtp_noms_ops/templates/security/senders_list.html
@@ -10,6 +10,9 @@
   {% include "security/forms/prison-switcher.html" %}
 {% endblock %}
 
+{% comment %}TODO: Move body_classes block to base.html when search V2 goes live to make all the existing pages consistent.{% endcomment %}
+{% block body_classes %}{{ block.super }} mtp-with-spaced-header{% endblock body_classes %}
+
 {% block inner_content %}
   <form id="filter-senders" class="mtp-security-search js-FormAnalytics" method="get">
 


### PR DESCRIPTION
_Note: the API changes have not being made so the actual search doesn't behave exactly as expected_

This:
- implements simple search for credits
- refactors the tests in test_views to use mixins
- refactors some tests to use the responses context manager instead of `responses.activate`
- changes the css to better match the designs

<img width="1033" alt="Screenshot 2019-07-19 at 16 13 39" src="https://user-images.githubusercontent.com/178865/61545905-69225f80-aa40-11e9-93b9-7dd100a36066.png">


The previous version didn't quite match the designs so I've made a few more visual changes.
As the new designs change the spacing around the header, I've decided to attach a new class to the body `mtp-with-spaced-header` so that we can select which pages have the new heading for now and when we are happy we could apply the class to all pages to make all of them consistent.

**Before**

<img width="1020" alt="Screenshot 2019-07-19 at 16 14 48" src="https://user-images.githubusercontent.com/178865/61545924-72133100-aa40-11e9-8f4b-9416c90ef04b.png">

**After**

<img width="991" alt="Screenshot 2019-07-19 at 16 13 46" src="https://user-images.githubusercontent.com/178865/61545941-78091200-aa40-11e9-942e-d9ea57773a80.png">


I've also refactored the test_views quite a lot to use Mixins for the different view groups to make it easier to implement the same for the other objects.

Sorry for the big PR, it's mainly because of the test_views, I've moved many bits around within the file.