### PR TITLE
Update copy when email not available in results list

### DIFF
--- a/mtp_noms_ops/templates/security/credits_list.html
+++ b/mtp_noms_ops/templates/security/credits_list.html
@@ -52,10 +52,8 @@
 
                 <td>
                   {{ credit.sender_name|default:_('Sender details not recorded') }}
-                  {% if credit.sender_email %}
-                    <br/>
-                    {{ credit.sender_email }}
-                  {% endif %}
+                  <br/>
+                  {{ credit.sender_email|default:_('Email not provided') }}
                 </td>
 
                 <td>

--- a/mtp_noms_ops/templates/security/disbursements_list.html
+++ b/mtp_noms_ops/templates/security/disbursements_list.html
@@ -58,10 +58,8 @@
 
                 <td>
                   {{ disbursement.recipient_first_name }} {{ disbursement.recipient_last_name }}
-                  {% if disbursement.recipient_email %}
-                    <br/>
-                    {{ disbursement.recipient_email }}
-                  {% endif %}
+                  <br/>
+                  {{ disbursement.recipient_email|default:_('Email not provided') }}
                 </td>
 
                 <td class="numeric">

--- a/mtp_noms_ops/templates/security/prisoners.html
+++ b/mtp_noms_ops/templates/security/prisoners.html
@@ -5,11 +5,6 @@
 
 {% block page_title %}{{ view.title }} – {{ block.super }}{% endblock %}
 
-{% block phase_banner %}
-  {{ block.super }}
-  {% include "security/forms/prison-switcher.html" %}
-{% endblock %}
-
 {% block inner_content %}
 
   <header>

--- a/mtp_noms_ops/templates/security/senders_list.html
+++ b/mtp_noms_ops/templates/security/senders_list.html
@@ -67,14 +67,18 @@
                     <td>
                       {% if sender.bank_transfer_details %}
                         {{ sender.bank_transfer_details.0.sender_name|default:'—' }}
+                        <br/>
+                        {% trans 'Email not provided' %}
                       {% elif sender.debit_card_details %}
                         {{ sender.debit_card_details.0.cardholder_names.0|default:'—' }}
                         {% comment %}TODO show when there are multiple cardholder names{% endcomment %}
+                        <br/>
 
                         {% if sender.debit_card_details.0.sender_emails %}
-                          <br/>
                           {{ sender.debit_card_details.0.sender_emails.0 }}
                           {% comment %}TODO show when there are multiple emails{% endcomment %}
+                        {% else %}
+                          {% trans 'Email not provided' %}
                         {% endif %}
 
                       {% else %}


### PR DESCRIPTION
**Before:**
When an email was not available the template was simply omitting any value.

**After:**
The text `Email not provided` is used instead.