### PR TITLE
Redesign no search results case for simple search V2

### DIFF
--- a/mtp_noms_ops/apps/security/views/object_base.py
+++ b/mtp_noms_ops/apps/security/views/object_base.py
@@ -158,6 +158,8 @@ class SecurityView(FormView):
         if self.redirect_on_single and len(object_list) == 1 and hasattr(self, 'url_for_single_result'):
             return redirect(self.url_for_single_result(object_list[0]))
         context[self.object_list_context_key] = object_list
+        # add objects as an alias for generic logic
+        context['objects'] = object_list
         return render(self.request, self.get_template_names(), context)
 
     def form_invalid(self, form):

--- a/mtp_noms_ops/templates/security/credits_list.html
+++ b/mtp_noms_ops/templates/security/credits_list.html
@@ -22,7 +22,7 @@
         </div>
     </div>
 
-    {% if form.is_valid %}
+    {% if form.is_valid and credits %}
       <div class="mtp-results-list-v2">
         <div class="print-hidden mtp-links--no-panel">
           <a class="js-print-trigger js-FormAnalytics-click" href="#print-dialog" data-click-track="print-{{ view.get_class_name }},{{ view.get_used_request_params|join:'&' }}">{% trans 'Print' %}</a>
@@ -73,10 +73,6 @@
                     {% trans 'View details' %}
                   </a>
                 </td>
-              </tr>
-            {% empty %}
-              <tr>
-                <td colspan="5">{% trans 'No matching credits found' %}</td>
               </tr>
             {% endfor %}
           </tbody>

--- a/mtp_noms_ops/templates/security/disbursements_list.html
+++ b/mtp_noms_ops/templates/security/disbursements_list.html
@@ -22,7 +22,7 @@
         </div>
     </div>
 
-    {% if form.is_valid %}
+    {% if form.is_valid and disbursements %}
       <div class="mtp-results-list-v2">
         <div class="print-hidden mtp-links--no-panel">
           <a class="js-print-trigger js-FormAnalytics-click" href="#print-dialog" data-click-track="print-{{ view.get_class_name }},{{ view.get_used_request_params|join:'&' }}">{% trans 'Print' %}</a>
@@ -73,10 +73,6 @@
                     {% trans 'View details' %}
                   </a>
                 </td>
-              </tr>
-            {% empty %}
-              <tr>
-                <td colspan="5">{% trans 'No matching disbursements found' %}</td>
               </tr>
             {% endfor %}
           </tbody>

--- a/mtp_noms_ops/templates/security/forms/top-area-object-list.html
+++ b/mtp_noms_ops/templates/security/forms/top-area-object-list.html
@@ -10,7 +10,11 @@
   {% include 'mtp_common/includes/message_box.html' %}
 
   <p class="mtp-search-description">
-  {{ form.search_description.description }}
+    {% if objects %}
+      {{ form.search_description.description }}
+    {% else %}
+      {% blocktrans with search_term=form.simple_search.value %}Your search for “<strong>{{ search_term }}</strong>” returned no results.{% endblocktrans %}
+    {% endif %}
   </p>
 {% else %}
   <header>

--- a/mtp_noms_ops/templates/security/prisoners_list.html
+++ b/mtp_noms_ops/templates/security/prisoners_list.html
@@ -21,7 +21,7 @@
         </div>
     </div>
 
-    {% if form.is_valid %}
+    {% if form.is_valid and prisoners %}
     <div class="mtp-results-list-wrapper">
       {% tabbedpanel cookie_name='mtp-tab-prisoners-results' collapsable=False tab_label=_('View credits or disbursements') css_class='govuk-grey' %}
 
@@ -74,10 +74,6 @@
                         {% trans 'View details' %}
                       </a>
                     </td>
-                  </tr>
-                {% empty %}
-                  <tr>
-                    <td colspan="5">{% trans 'No matching prisoners found' %}</td>
                   </tr>
                 {% endfor %}
               </tbody>
@@ -146,10 +142,6 @@
                         {% trans 'View details' %}
                       </a>
                     </td>
-                  </tr>
-                {% empty %}
-                  <tr>
-                    <td colspan="5">{% trans 'No matching prisoners found' %}</td>
                   </tr>
                 {% endfor %}
               </tbody>

--- a/mtp_noms_ops/templates/security/senders_list.html
+++ b/mtp_noms_ops/templates/security/senders_list.html
@@ -36,7 +36,7 @@
         </div>
     </div>
 
-    {% if form.is_valid %}
+    {% if form.is_valid and senders %}
       <div class="mtp-results-list-v2">
         <div class="print-hidden mtp-links--no-panel">
           <a class="js-print-trigger js-FormAnalytics-click" href="#print-dialog" data-click-track="print-{{ view.get_class_name }},{{ view.get_used_request_params|join:'&' }}">{% trans 'Print' %}</a>
@@ -122,10 +122,6 @@
                   </tr>
                 {% endif %}
               {% endwith %}
-            {% empty %}
-              <tr>
-                <td colspan="7">{% trans 'No matching payment sources found' %}</td>
-              </tr>
             {% endfor %}
           </tbody>
         </table>


### PR DESCRIPTION
Hide the results list and change the copy to say that there were no results.

**Before**

<img width="1012" alt="Screenshot 2019-07-31 at 15 36 45" src="https://user-images.githubusercontent.com/178865/62221161-1e420980-b3a9-11e9-9ea4-e080e77dd931.png">



**After**

<img width="1022" alt="Screenshot 2019-07-31 at 15 37 16" src="https://user-images.githubusercontent.com/178865/62221170-21d59080-b3a9-11e9-9b74-ff8a523f765d.png">

