### PR TITLE
Highlight search term when using simple search

### DIFF
--- a/mtp_noms_ops/assets-src/stylesheets/views/_security-results.scss
+++ b/mtp_noms_ops/assets-src/stylesheets/views/_security-results.scss
@@ -140,3 +140,18 @@
 .mtp-results-list-wrapper {
   margin-top: 50px;
 }
+
+.mtp-search-highlight {
+  border-bottom: 3px solid #ffbf47;
+  margin-right: 1px;
+  background-color: #fff2d3;
+  padding: 2px 0px 0px;
+
+  // reset with print as IE8 doesn't support @media not print for the rule above
+  @media print {
+    border-bottom: 0;
+    margin-right: 0;
+    background-color: transparent;
+    padding: 0;
+  }
+}

--- a/mtp_noms_ops/templates/security/credits_list.html
+++ b/mtp_noms_ops/templates/security/credits_list.html
@@ -22,7 +22,7 @@
         </div>
     </div>
 
-    {% if form.is_valid and credits %}
+    {% if form.is_valid and credits %}{% setup_highlight %}
       <div class="mtp-results-list-v2">
         <div class="print-hidden mtp-links--no-panel">
           <a class="js-print-trigger js-FormAnalytics-click" href="#print-dialog" data-click-track="print-{{ view.get_class_name }},{{ view.get_used_request_params|join:'&' }}">{% trans 'Print' %}</a>
@@ -51,15 +51,15 @@
                 </td>
 
                 <td>
-                  {{ credit.sender_name|default:_('Sender details not recorded') }}
+                  {% search_highlight credit.sender_name default=_('Sender details not recorded') %}
                   <br/>
-                  {{ credit.sender_email|default:_('Email not provided') }}
+                  {% search_highlight credit.sender_email default=_('Email not provided') %}
                 </td>
 
                 <td>
                   {{ credit.prisoner_name|default:_('Unknown prisoner') }}
                   <br/>
-                  {{ credit.prisoner_number }}
+                  {% search_highlight credit.prisoner_number %}
                 </td>
 
                 <td class="numeric">

--- a/mtp_noms_ops/templates/security/disbursements_list.html
+++ b/mtp_noms_ops/templates/security/disbursements_list.html
@@ -22,7 +22,7 @@
         </div>
     </div>
 
-    {% if form.is_valid and disbursements %}
+    {% if form.is_valid and disbursements %}{% setup_highlight %}
       <div class="mtp-results-list-v2">
         <div class="print-hidden mtp-links--no-panel">
           <a class="js-print-trigger js-FormAnalytics-click" href="#print-dialog" data-click-track="print-{{ view.get_class_name }},{{ view.get_used_request_params|join:'&' }}">{% trans 'Print' %}</a>
@@ -53,11 +53,11 @@
                 <td>
                   {{ disbursement.prisoner_name|default:_('Unknown prisoner') }}
                   <br/>
-                  {{ disbursement.prisoner_number }}
+                  {% search_highlight disbursement.prisoner_number %}
                 </td>
 
                 <td>
-                  {{ disbursement.recipient_first_name }} {{ disbursement.recipient_last_name }}
+                  {% search_highlight disbursement.recipient_first_name %} {% search_highlight  disbursement.recipient_last_name %}
                   <br/>
                   {{ disbursement.recipient_email|default:_('Email not provided') }}
                 </td>

--- a/mtp_noms_ops/templates/security/prisoners_list.html
+++ b/mtp_noms_ops/templates/security/prisoners_list.html
@@ -21,7 +21,7 @@
         </div>
     </div>
 
-    {% if form.is_valid and prisoners %}
+    {% if form.is_valid and prisoners %}{% setup_highlight %}
     <div class="mtp-results-list-wrapper">
       {% tabbedpanel cookie_name='mtp-tab-prisoners-results' collapsable=False tab_label=_('View credits or disbursements') css_class='govuk-grey' %}
 
@@ -50,9 +50,9 @@
                 {% for prisoner in prisoners %}
                   <tr>
                     <td>
-                      {{ prisoner.prisoner_name|default:_('Unknown prisoner') }}
+                      {% search_highlight prisoner.prisoner_name default=_('Unknown prisoner') %}
                       <br/>
-                      {{ prisoner.prisoner_number }}
+                      {% search_highlight prisoner.prisoner_number %}
                     </td>
                     <td class="numeric">
                       <span class="mtp-sortable-cell--pad">
@@ -118,9 +118,9 @@
                 {% for prisoner in prisoners %}
                   <tr>
                     <td>
-                      {{ prisoner.prisoner_name|default:_('Unknown prisoner') }}
+                      {% search_highlight prisoner.prisoner_name default=_('Unknown prisoner') %}
                       <br/>
-                      {{ prisoner.prisoner_number }}
+                      {% search_highlight prisoner.prisoner_number %}
                     </td>
                     <td class="numeric">
                       <span class="mtp-sortable-cell--pad">

--- a/mtp_noms_ops/templates/security/senders_list.html
+++ b/mtp_noms_ops/templates/security/senders_list.html
@@ -36,7 +36,7 @@
         </div>
     </div>
 
-    {% if form.is_valid and senders %}
+    {% if form.is_valid and senders %}{% setup_highlight %}
       <div class="mtp-results-list-v2">
         <div class="print-hidden mtp-links--no-panel">
           <a class="js-print-trigger js-FormAnalytics-click" href="#print-dialog" data-click-track="print-{{ view.get_class_name }},{{ view.get_used_request_params|join:'&' }}">{% trans 'Print' %}</a>
@@ -66,16 +66,16 @@
                   <tr>
                     <td>
                       {% if sender.bank_transfer_details %}
-                        {{ sender.bank_transfer_details.0.sender_name|default:'—' }}
+                        {% search_highlight sender.bank_transfer_details.0.sender_name default='—' %}
                         <br/>
                         {% trans 'Email not provided' %}
                       {% elif sender.debit_card_details %}
-                        {{ sender.debit_card_details.0.cardholder_names.0|default:'—' }}
+                        {% search_highlight sender.debit_card_details.0.cardholder_names.0 default='—' %}
                         {% comment %}TODO show when there are multiple cardholder names{% endcomment %}
                         <br/>
 
                         {% if sender.debit_card_details.0.sender_emails %}
-                          {{ sender.debit_card_details.0.sender_emails.0 }}
+                          {% search_highlight sender.debit_card_details.0.sender_emails.0 %}
                           {% comment %}TODO show when there are multiple emails{% endcomment %}
                         {% else %}
                           {% trans 'Email not provided' %}


### PR DESCRIPTION
This adds 2 template tags to highlight search terms.

- `search_highlight` which wraps the text with a span
- `setup_hightlight` which caches the regex pattern so that it doesn't have to be computed every time

<img width="1083" alt="Screenshot 2019-08-02 at 11 26 17" src="https://user-images.githubusercontent.com/178865/62364096-9a0e9400-b518-11e9-8ce5-0a7d4ca66289.png">
