### PR TITLE
Show best matching email/cardholder name in sender search results

### DIFF
--- a/mtp_noms_ops/apps/security/templatetags/security.py
+++ b/mtp_noms_ops/apps/security/templatetags/security.py
@@ -255,3 +255,37 @@ def search_highlight(context, value, default=''):
             search_terms_re.sub(r'<span class="mtp-search-highlight">\1</span>', value),
         )
     return value
+
+
+@register.simple_tag(takes_context=True)
+def extract_best_match(context, items):
+    """
+    Takes a list and returns a dict with:
+    - 'item': best item in the list that matches the search term
+    - 'total_remaining': total number of other items in the list
+
+    The best match equals a random item in the list if the user is not not on the
+    search results page or if there's no match in the list.
+    """
+    item_list = items or []
+    best_match = None
+
+    search_terms_re = _get_cached_search_terms_re(context)
+
+    if search_terms_re:
+        best_match = next(
+            (
+                item
+                for item in item_list
+                if search_terms_re.search(item)
+            ),
+            None,
+        )
+
+    if not best_match and item_list:
+        best_match = item_list[0]
+
+    return {
+        'item': best_match,
+        'total_remaining': max(len(item_list)-1, 0),
+    }

--- a/mtp_noms_ops/templates/security/forms/prison-switcher.html
+++ b/mtp_noms_ops/templates/security/forms/prison-switcher.html
@@ -14,7 +14,6 @@
           {% blocktrans trimmed with total_remaining=split_prison_names.total_remaining %}
             and {{ total_remaining }} more
           {% endblocktrans %}
-        {% else %}
         {% endif %}
       {% endif %}
     </div>

--- a/mtp_noms_ops/templates/security/senders_list.html
+++ b/mtp_noms_ops/templates/security/senders_list.html
@@ -70,15 +70,31 @@
                         <br/>
                         {% trans 'Email not provided' %}
                       {% elif sender.debit_card_details %}
-                        {% search_highlight sender.debit_card_details.0.cardholder_names.0 default='—' %}
-                        {% comment %}TODO show when there are multiple cardholder names{% endcomment %}
+
+                        {% extract_best_match sender.debit_card_details.0.cardholder_names as match %}
+                        {% search_highlight match.item default='-' %}
+
+                        {% if match.total_remaining %}
+                          <br/>
+                          {% blocktrans trimmed count total_remaining=match.total_remaining %}
+                            and {{ total_remaining }} more name
+                          {% plural %}
+                            and {{ total_remaining }} more names
+                          {% endblocktrans %}
+                        {% endif %}
+
                         <br/>
 
-                        {% if sender.debit_card_details.0.sender_emails %}
-                          {% search_highlight sender.debit_card_details.0.sender_emails.0 %}
-                          {% comment %}TODO show when there are multiple emails{% endcomment %}
-                        {% else %}
-                          {% trans 'Email not provided' %}
+                        {% extract_best_match sender.debit_card_details.0.sender_emails as match %}
+                        {% search_highlight match.item default=_('Email not provided') %}
+
+                        {% if match.total_remaining %}
+                          <br/>
+                          {% blocktrans trimmed count total_remaining=match.total_remaining %}
+                            and {{ total_remaining }} more email address
+                          {% plural %}
+                            and {{ total_remaining }} more email addresses
+                          {% endblocktrans %}
                         {% endif %}
 
                       {% else %}


### PR DESCRIPTION
A sender can have more than one email address and more than one cardholder name.

This adds a new template tag which makes it possible to implement a succinct `<best matching item> and more`.

As we want to highlight the search term on the results page, the template tag extract the best match in the list.

<img width="1011" alt="Screenshot 2019-08-02 at 15 55 40" src="https://user-images.githubusercontent.com/178865/62380825-fa65fb80-b541-11e9-8b1d-dac7fc1398ea.png">

