### PR TITLE
Make search highlighting more robust

### DIFF
--- a/mtp_noms_ops/apps/security/templatetags/security.py
+++ b/mtp_noms_ops/apps/security/templatetags/security.py
@@ -215,7 +215,7 @@ def _build_search_terms_re(context):
     if not search_term:
         return None
 
-    search_terms = search_term.split()
+    search_terms = [re.escape(term) for term in search_term.split()]
     return re.compile(f'({"|".join(search_terms)})', re.I)
 
 

--- a/mtp_noms_ops/apps/security/tests/test_templatetags.py
+++ b/mtp_noms_ops/apps/security/tests/test_templatetags.py
@@ -129,6 +129,24 @@ class TestSearchHighlight(SimpleTestCase):
                 expected_result,
             )
 
+    def test_escapes_terms(self):
+        """
+        Test that value is escaped so that it's considered raw.
+        """
+        context = {
+            'is_search_results': True,
+            'form': mock.Mock(
+                cleaned_data={
+                    'simple_search': 'a|b',
+                },
+            ),
+        }
+
+        self.assertEqual(
+            search_highlight(context, 'a b a|b'),
+            'a b <span class="mtp-search-highlight">a|b</span>',
+        )
+
     def test_does_not_replace_if_not_on_search_results_page(self):
         """
         Test that if `is_search_results` can't be found in context, the template tag doesn't do anything.

--- a/mtp_noms_ops/apps/security/tests/test_templatetags.py
+++ b/mtp_noms_ops/apps/security/tests/test_templatetags.py
@@ -129,9 +129,9 @@ class TestSearchHighlight(SimpleTestCase):
                 expected_result,
             )
 
-    def test_escapes_terms(self):
+    def test_regex_escapes_terms(self):
         """
-        Test that value is escaped so that it's considered raw.
+        Test that the regex value is escaped so that it's considered raw.
         """
         context = {
             'is_search_results': True,
@@ -145,6 +145,24 @@ class TestSearchHighlight(SimpleTestCase):
         self.assertEqual(
             search_highlight(context, 'a b a|b'),
             'a b <span class="mtp-search-highlight">a|b</span>',
+        )
+
+    def test_html_escapes_value(self):
+        """
+        Test that the test value is escaped before being wrapped in the highlight span.
+        """
+        context = {
+            'is_search_results': True,
+            'form': mock.Mock(
+                cleaned_data={
+                    'simple_search': '<a>test</a>',
+                },
+            ),
+        }
+
+        self.assertEqual(
+            search_highlight(context, 'some <a>test</a> string'),
+            'some <span class="mtp-search-highlight">&lt;a&gt;test&lt;/a&gt;</span> string',
         )
 
     def test_does_not_replace_if_not_on_search_results_page(self):


### PR DESCRIPTION
This:
- escapes the regex pattern so that a search term containing regex meaningful rules is treated as a raw string
- escapes the input value before wrapping search terms with highlight spans so that it's not mistakenly treated as html safe