### PR TITLE
Credits advanced search

### DIFF
--- a/mtp_noms_ops/apps/security/forms/object_base.py
+++ b/mtp_noms_ops/apps/security/forms/object_base.py
@@ -27,6 +27,9 @@ from security.utils import convert_date_fields
 
 
 def get_credit_source_choices():
+    """
+    TODO: delete after search V2 goes live.
+    """
     return [
         ('', _('Any method')),  # blank option
         *credit_sources.items(),
@@ -34,6 +37,9 @@ def get_credit_source_choices():
 
 
 def get_disbursement_method_choices():
+    """
+    TODO: delete after search V2 goes live.
+    """
     return [
         ('', _('Any method')),  # blank option
         *disbursement_methods.items(),
@@ -63,6 +69,9 @@ def validate_prisoner_number(prisoner_number):
 
 
 def validate_range_fields(*fields):
+    """
+    TODO: delete after search V2 goes live.
+    """
     def inner(cls):
         base_clean = cls.clean
 

--- a/mtp_noms_ops/apps/security/forms/object_base.py
+++ b/mtp_noms_ops/apps/security/forms/object_base.py
@@ -27,23 +27,17 @@ from security.utils import convert_date_fields
 
 
 def get_credit_source_choices():
-    return insert_blank_option(
-        list(credit_sources.items()),
-        title=_('Any method')
-    )
+    return [
+        ('', _('Any method')),  # blank option
+        *credit_sources.items(),
+    ]
 
 
 def get_disbursement_method_choices():
-    return insert_blank_option(
-        list(disbursement_methods.items()),
-        title=_('Any method')
-    )
-
-
-def insert_blank_option(choices, title):
-    new_choices = [('', title)]
-    new_choices.extend(choices)
-    return new_choices
+    return [
+        ('', _('Any method')),  # blank option
+        *disbursement_methods.items(),
+    ]
 
 
 def parse_amount(value, as_int=True):
@@ -100,10 +94,22 @@ class AmountPattern(enum.Enum):
 
     @classmethod
     def get_choices(cls):
-        return [(choice.name, choice.value) for choice in cls]
+        """
+        Returns list of choices to be used in forms. It also includes a blank option.
+        """
+        return [
+            ('', _('Any amount')),
+            *[
+                (choice.name, choice.value)
+                for choice in cls
+            ],
+        ]
 
     @classmethod
     def update_query_data(cls, query_data):
+        """
+        TODO: delete after search V2 goes live.
+        """
         amount_pattern = query_data.pop('amount_pattern', None)
         try:
             amount_pattern = cls[amount_pattern]
@@ -174,21 +180,21 @@ class SecurityForm(GARequestErrorReportingMixin, forms.Form):
                 self.data.setlist('prison', selected_prisons)
 
             if 'prison_region' in self.fields:
-                self['prison_region'].field.choices = insert_blank_option(
-                    self.prison_list.region_choices,
-                    title=_('All regions'),
-                )
+                self['prison_region'].field.choices = [
+                    ('', _('All regions')),
+                    *self.prison_list.region_choices,
+                ]
             if 'prison_population' in self.fields:
-                self['prison_population'].field.choices = insert_blank_option(
-                    self.prison_list.population_choices,
-                    title=_('All types'),
-                )
+                self['prison_population'].field.choices = [
+                    ('', _('All types')),  # blank option
+                    *self.prison_list.population_choices,
+                ]
 
             if 'prison_category' in self.fields:
-                self['prison_category'].field.choices = insert_blank_option(
-                    self.prison_list.category_choices,
-                    title=_('All categories'),
-                )
+                self['prison_category'].field.choices = [
+                    ('', _('All categories')),  # blank option
+                    *self.prison_list.category_choices,
+                ]
 
     @cached_property
     def session(self):

--- a/mtp_noms_ops/apps/security/forms/object_list.py
+++ b/mtp_noms_ops/apps/security/forms/object_list.py
@@ -658,7 +658,7 @@ class CreditsForm(BaseCreditsForm):
         return str(description).lower() if description else None
 
 
-class CreditsFormV2(SearchFormV2Mixin, BaseCreditsForm):
+class CreditsFormV2(SearchFormV2Mixin, AmountSearchFormMixin, BaseCreditsForm):
     """
     Search Form for Credits V2.
     """

--- a/mtp_noms_ops/apps/security/forms/object_list.py
+++ b/mtp_noms_ops/apps/security/forms/object_list.py
@@ -668,6 +668,25 @@ class CreditsFormV2(SearchFormV2Mixin, AmountSearchFormMixin, BaseCreditsForm):
         help_text=_('Common or incomplete names may show many results'),
     )
 
+    sender_name = forms.CharField(label=_('Name'), required=False)
+    sender_email = forms.CharField(label=_('Email'), required=False)
+    sender_postcode = forms.CharField(label=_('Postcode'), required=False)
+    sender_ip_address = forms.CharField(
+        label=_('IP Address'),
+        validators=[validate_ipv4_address],
+        required=False,
+    )
+    card_number_last_digits = forms.CharField(label=_('Last 4 digits of card number'), max_length=4, required=False)
+    sender_account_number = forms.CharField(label=_('Account number'), required=False)
+    sender_sort_code = forms.CharField(label=_('Sort code'), required=False)
+
+    prisoner_name = forms.CharField(label=_('Prisoner name'), required=False)
+    prisoner_number = forms.CharField(
+        label=_('Prisoner number'),
+        validators=[validate_prisoner_number],
+        required=False,
+    )
+
     # NB: ensure that these templates are HTML-safe
     filtered_description_template = 'Results containing {filter_description}.'
     unfiltered_description_template = ''
@@ -677,6 +696,24 @@ class CreditsFormV2(SearchFormV2Mixin, AmountSearchFormMixin, BaseCreditsForm):
     )
     description_capitalisation = {}
     unlisted_description = ''
+
+    def clean_sender_postcode(self):
+        sender_postcode = self.cleaned_data.get('sender_postcode')
+        return remove_whitespaces_and_hyphens(sender_postcode)
+
+    def clean_sender_sort_code(self):
+        sender_sort_code = self.cleaned_data.get('sender_sort_code')
+        return remove_whitespaces_and_hyphens(sender_sort_code)
+
+    def clean_prisoner_number(self):
+        """
+        Make sure prisoner number is always uppercase.
+        """
+        prisoner_number = self.cleaned_data.get('prisoner_number')
+        if not prisoner_number:
+            return prisoner_number
+
+        return prisoner_number.upper()
 
 
 class BaseDisbursementsForm(SecurityForm):

--- a/mtp_noms_ops/apps/security/tests/test_forms.py
+++ b/mtp_noms_ops/apps/security/tests/test_forms.py
@@ -264,11 +264,17 @@ class AmountSearchFormMixinTestCase(SimpleTestCase):
                 {'amount_pence': ['This field is required for the selected amount pattern.']},
             ),
             ValidationScenario(
-                {'amount_pattern': AmountPattern.pence.name, 'amount_pence': -1},
+                {
+                    'amount_pattern': AmountPattern.pence.name,
+                    'amount_pence': -1,
+                },
                 {'amount_pence': ['Ensure this value is greater than or equal to 0.']},
             ),
             ValidationScenario(
-                {'amount_pattern': AmountPattern.pence.name, 'amount_pence': 100},
+                {
+                    'amount_pattern': AmountPattern.pence.name,
+                    'amount_pence': 100,
+                },
                 {'amount_pence': ['Ensure this value is less than or equal to 99.']},
             ),
             ValidationScenario(
@@ -276,15 +282,24 @@ class AmountSearchFormMixinTestCase(SimpleTestCase):
                 {'amount_pattern': ['Select a valid choice. invalid is not one of the available choices.']},
             ),
             ValidationScenario(
-                {'amount_pattern': AmountPattern.exact.name, 'amount_exact': '$100'},
+                {
+                    'amount_pattern': AmountPattern.exact.name,
+                    'amount_exact': '$100',
+                },
                 {'amount_exact': ['Invalid amount.']},
             ),
             ValidationScenario(
-                {'amount_pattern': AmountPattern.exact.name, 'amount_exact': '£100.0.0'},
+                {
+                    'amount_pattern': AmountPattern.exact.name,
+                    'amount_exact': '£100.0.0',
+                },
                 {'amount_exact': ['Invalid amount.']},
             ),
             ValidationScenario(
-                {'amount_pattern': AmountPattern.exact.name, 'amount_exact': 'one'},
+                {
+                    'amount_pattern': AmountPattern.exact.name,
+                    'amount_exact': 'one',
+                },
                 {'amount_exact': ['Invalid amount.']},
             ),
         ]
@@ -699,7 +714,7 @@ class SenderFormV2TestCase(SecurityFormTestCase):
                 {'prison': ['Select a valid choice. invalid is not one of the available choices.']},
             ),
             ValidationScenario(
-                {'card_number_last_digits': ['12345']},
+                {'card_number_last_digits': '12345'},
                 {'card_number_last_digits': ['You’ve entered too many characters']},
             ),
         ]
@@ -968,7 +983,7 @@ class PrisonerFormV2TestCase(SecurityFormTestCase):
                 {'prison': ['Select a valid choice. invalid is not one of the available choices.']},
             ),
             ValidationScenario(
-                {'prisoner_number': ['invalid']},
+                {'prisoner_number': 'invalid'},
                 {'prisoner_number': ['Invalid prisoner number.']},
             ),
         ]
@@ -1094,6 +1109,15 @@ class CreditFormV2TestCase(SecurityFormTestCase):
                 'amount_pattern': '',
                 'amount_exact': '',
                 'amount_pence': '',
+                'prisoner_name': '',
+                'prisoner_number': '',
+                'sender_name': '',
+                'sender_email': '',
+                'sender_postcode': '',
+                'sender_ip_address': '',
+                'card_number_last_digits': '',
+                'sender_sort_code': '',
+                'sender_account_number': '',
             },
         )
         self.assertDictEqual(
@@ -1148,6 +1172,15 @@ class CreditFormV2TestCase(SecurityFormTestCase):
                 'amount_pattern': '',
                 'amount_exact': '',
                 'amount_pence': '',
+                'prisoner_name': '',
+                'prisoner_number': '',
+                'sender_name': '',
+                'sender_email': '',
+                'sender_postcode': '',
+                'sender_ip_address': '',
+                'card_number_last_digits': '',
+                'sender_sort_code': '',
+                'sender_account_number': '',
             },
         )
 
@@ -1183,6 +1216,15 @@ class CreditFormV2TestCase(SecurityFormTestCase):
                     'amount_pattern': AmountPattern.exact.name,
                     'amount_exact': '100.00',
                     'amount_pence': '',
+                    'prisoner_name': 'Jane Doe',
+                    'prisoner_number': 'a2624ae',
+                    'sender_name': 'John Doe',
+                    'sender_email': 'johndoe',
+                    'sender_postcode': 'SW1A 1a-a',
+                    'sender_ip_address': '127.0.0.1',
+                    'card_number_last_digits': '1234',
+                    'sender_account_number': '123456789',
+                    'sender_sort_code': '11-22 - 33',
                 },
             )
 
@@ -1198,6 +1240,15 @@ class CreditFormV2TestCase(SecurityFormTestCase):
                     'ordering': ['-amount'],
                     'prison': ['IXB'],
                     'amount': ['10000'],
+                    'prisoner_name': ['Jane Doe'],
+                    'prisoner_number': ['A2624AE'],
+                    'sender_name': ['John Doe'],
+                    'sender_email': ['johndoe'],
+                    'sender_postcode': ['SW1A1aa'],
+                    'sender_ip_address': ['127.0.0.1'],
+                    'card_number_last_digits': ['1234'],
+                    'sender_account_number': ['123456789'],
+                    'sender_sort_code': ['112233'],
                 },
             )
 
@@ -1214,6 +1265,15 @@ class CreditFormV2TestCase(SecurityFormTestCase):
                 'amount_pattern': AmountPattern.exact.name,
                 'amount_exact': '100.00',
                 'amount_pence': '',
+                'prisoner_name': 'Jane Doe',
+                'prisoner_number': 'A2624AE',
+                'sender_name': 'John Doe',
+                'sender_email': 'johndoe',
+                'sender_postcode': 'SW1A1aa',
+                'sender_ip_address': '127.0.0.1',
+                'card_number_last_digits': '1234',
+                'sender_account_number': '123456789',
+                'sender_sort_code': '112233',
             },
         )
 
@@ -1226,6 +1286,15 @@ class CreditFormV2TestCase(SecurityFormTestCase):
                     prisons[0]['nomis_id'],
                 ],
                 'amount': '10000',
+                'prisoner_name': 'Jane Doe',
+                'prisoner_number': 'A2624AE',
+                'sender_name': 'John Doe',
+                'sender_email': 'johndoe',
+                'sender_postcode': 'SW1A1aa',
+                'sender_ip_address': '127.0.0.1',
+                'card_number_last_digits': '1234',
+                'sender_account_number': '123456789',
+                'sender_sort_code': '112233',
             },
         )
 
@@ -1245,6 +1314,18 @@ class CreditFormV2TestCase(SecurityFormTestCase):
             ValidationScenario(
                 {'prison': ['invalid']},
                 {'prison': ['Select a valid choice. invalid is not one of the available choices.']},
+            ),
+            ValidationScenario(
+                {'prisoner_number': 'invalid'},
+                {'prisoner_number': ['Invalid prisoner number.']},
+            ),
+            ValidationScenario(
+                {'card_number_last_digits': '12345'},
+                {'card_number_last_digits': ['You’ve entered too many characters']},
+            ),
+            ValidationScenario(
+                {'sender_ip_address': '256.0.0.1'},
+                {'sender_ip_address': ['Enter a valid IPv4 address.']},
             ),
         ]
 

--- a/mtp_noms_ops/apps/security/tests/test_forms.py
+++ b/mtp_noms_ops/apps/security/tests/test_forms.py
@@ -1118,6 +1118,8 @@ class CreditFormV2TestCase(SecurityFormTestCase):
                 'card_number_last_digits': '',
                 'sender_sort_code': '',
                 'sender_account_number': '',
+                'received_at__gte': None,
+                'received_at__lt': None,
             },
         )
         self.assertDictEqual(
@@ -1181,6 +1183,8 @@ class CreditFormV2TestCase(SecurityFormTestCase):
                 'card_number_last_digits': '',
                 'sender_sort_code': '',
                 'sender_account_number': '',
+                'received_at__gte': None,
+                'received_at__lt': None,
             },
         )
 
@@ -1225,6 +1229,12 @@ class CreditFormV2TestCase(SecurityFormTestCase):
                     'card_number_last_digits': '1234',
                     'sender_account_number': '123456789',
                     'sender_sort_code': '11-22 - 33',
+                    'received_at__gte_0': '1',
+                    'received_at__gte_1': '2',
+                    'received_at__gte_2': '2000',
+                    'received_at__lt_0': '10',
+                    'received_at__lt_1': '3',
+                    'received_at__lt_2': '2000',
                 },
             )
 
@@ -1249,6 +1259,8 @@ class CreditFormV2TestCase(SecurityFormTestCase):
                     'card_number_last_digits': ['1234'],
                     'sender_account_number': ['123456789'],
                     'sender_sort_code': ['112233'],
+                    'received_at__gte': ['2000-02-01'],
+                    'received_at__lt': ['2000-03-11'],
                 },
             )
 
@@ -1274,6 +1286,8 @@ class CreditFormV2TestCase(SecurityFormTestCase):
                 'card_number_last_digits': '1234',
                 'sender_account_number': '123456789',
                 'sender_sort_code': '112233',
+                'received_at__gte': datetime.date(2000, 2, 1),
+                'received_at__lt': datetime.date(2000, 3, 10),
             },
         )
 
@@ -1295,7 +1309,36 @@ class CreditFormV2TestCase(SecurityFormTestCase):
                 'card_number_last_digits': '1234',
                 'sender_account_number': '123456789',
                 'sender_sort_code': '112233',
+                'received_at__gte': datetime.date(2000, 2, 1),
+                'received_at__lt': datetime.date(2000, 3, 10),
             },
+        )
+
+        # make sure the values for dates are split
+        self.assertDictEqual(
+            parse_qs(form.query_string),
+            {
+                'ordering': ['-amount'],
+                'prison': ['IXB'],
+                'amount_pattern': ['exact'],
+                'amount_exact': ['100.00'],
+                'advanced': ['True'],
+                'sender_name': ['John Doe'],
+                'sender_email': ['johndoe'],
+                'sender_postcode': ['SW1A1aa'],
+                'sender_ip_address': ['127.0.0.1'],
+                'card_number_last_digits': ['1234'],
+                'sender_account_number': ['123456789'],
+                'sender_sort_code': ['112233'],
+                'prisoner_name': ['Jane Doe'],
+                'prisoner_number': ['A2624AE'],
+                'received_at__gte_0': ['1'],
+                'received_at__gte_1': ['2'],
+                'received_at__gte_2': ['2000'],
+                'received_at__lt_0': ['10'],
+                'received_at__lt_1': ['3'],
+                'received_at__lt_2': ['2000']
+            }
         )
 
     def test_invalid(self):
@@ -1326,6 +1369,31 @@ class CreditFormV2TestCase(SecurityFormTestCase):
             ValidationScenario(
                 {'sender_ip_address': '256.0.0.1'},
                 {'sender_ip_address': ['Enter a valid IPv4 address.']},
+            ),
+            ValidationScenario(
+                {
+                    'received_at__gte_0': '2',
+                    'received_at__gte_1': '2',
+                    'received_at__gte_2': '2000',
+                    'received_at__lt_0': '1',
+                    'received_at__lt_1': '2',
+                    'received_at__lt_2': '2000',
+                },
+                {'received_at__lt': ['Must be after the start date.']},
+            ),
+            ValidationScenario(
+                {
+                    'received_at__gte_0': '32',
+                    'received_at__gte_1': '13',
+                    'received_at__gte_2': '1111',
+                },
+                {
+                    'received_at__gte': [
+                        '‘Day’ should be between 1 and 31',
+                        '‘Month’ should be between 1 and 12',
+                        '‘Year’ should be between 1900 and 2019',
+                    ],
+                },
             ),
         ]
 

--- a/mtp_noms_ops/apps/security/tests/test_views.py
+++ b/mtp_noms_ops/apps/security/tests/test_views.py
@@ -1323,6 +1323,7 @@ class PrisonerViewsV2TestCase(
     Test case related to prisoner search V2 and detail views.
     """
     view_name = 'security:prisoner_list'
+    advanced_search_view_name = 'security:prisoners_advanced_search'
     search_results_view_name = 'security:prisoner_search_results'
     detail_view_name = 'security:prisoner_detail'
     search_ordering = '-sender_count'

--- a/mtp_noms_ops/apps/security/tests/test_views.py
+++ b/mtp_noms_ops/apps/security/tests/test_views.py
@@ -1580,6 +1580,7 @@ class CreditViewsV2TestCase(SearchV2SecurityTestCaseMixin, ExportSecurityViewTes
     Test case related to credit search V2 and detail views.
     """
     view_name = 'security:credit_list'
+    advanced_search_view_name = 'security:credits_advanced_search'
     search_results_view_name = 'security:credit_search_results'
     detail_view_name = 'security:credit_detail'
     search_ordering = '-received_at'
@@ -1704,6 +1705,12 @@ class CreditViewsV2TestCase(SearchV2SecurityTestCaseMixin, ExportSecurityViewTes
         ],
     ]
 
+    def get_api_object_list_response_data(self):
+        return [
+            self.debit_card_credit,
+            self.bank_transfer_credit,
+        ]
+
     def _test_search_results_content(self, response):
         self.assertContains(response, '2 credits')
 
@@ -1798,12 +1805,6 @@ class CreditViewsV2TestCase(SearchV2SecurityTestCaseMixin, ExportSecurityViewTes
                     ),
                 )
         self.assertEqual(response.status_code, 404)
-
-    def get_api_object_list_response_data(self):
-        return [
-            self.debit_card_credit,
-            self.bank_transfer_credit,
-        ]
 
 
 class DisbursementViewsTestCase(SecurityViewTestCase):

--- a/mtp_noms_ops/apps/security/urls.py
+++ b/mtp_noms_ops/apps/security/urls.py
@@ -63,6 +63,15 @@ urlpatterns = [
         name='credit_list',
     ),
     url(
+        r'^credits/advanced-search/$',
+        security_test(
+            views.CreditListViewV2.as_view(
+                view_type=views.ViewType.advanced_search_form,
+            ),
+        ),
+        name='credits_advanced_search',
+    ),
+    url(
         r'^credits/search-results/$',
         security_test(
             views.CreditListViewV2.as_view(

--- a/mtp_noms_ops/apps/security/views/object_list.py
+++ b/mtp_noms_ops/apps/security/views/object_list.py
@@ -37,8 +37,10 @@ class CreditListViewV2(SecurityView):
     title = _('Credits')
     form_class = CreditsFormV2
     template_name = 'security/credits_list.html'
+    advanced_search_template_name = 'security/credits_advanced_search.html'
     search_results_view = 'security:credit_search_results'
     simple_search_view = 'security:credit_list'
+    advanced_search_view = 'security:credits_advanced_search'
     object_list_context_key = 'credits'
     object_name = _('credit')
     object_name_plural = _('credits')

--- a/mtp_noms_ops/assets-src/javascripts/modules/security-forms.js
+++ b/mtp_noms_ops/assets-src/javascripts/modules/security-forms.js
@@ -11,22 +11,36 @@ exports.SecurityForms = {
 
   bindAmountPatternSelection: function () {
     var $patternSelect = $('#id_amount_pattern');
+    var valueGetter = function() { return $patternSelect.val() };
+
+    // if $patternSelect doesn't exist, check if the radio varient exists instead
+    if (!$patternSelect.length && $('[name=amount_pattern]')) {
+      $patternSelect = $('[name=amount_pattern]');
+      valueGetter = function() { return $patternSelect.filter(':checked').val(); };
+    }
+
     var $exactWrapper = $('#id_amount_exact-wrapper');
     var $penceWrapper = $('#id_amount_pence-wrapper');
 
+    var hideWrapper = function(wrapper) {
+      wrapper.removeClass('form-group-error').hide();
+      wrapper.find('input').val('').removeClass('form-control-error');
+      wrapper.find('.error-message').remove();
+    };
+
     function update () {
-      switch ($patternSelect.val()) {
+      switch (valueGetter()) {
         case 'exact':
           $exactWrapper.show();
-          $penceWrapper.hide();
+          hideWrapper($penceWrapper);
           break;
         case 'pence':
-          $exactWrapper.hide();
+          hideWrapper($exactWrapper);
           $penceWrapper.show();
           break;
         default:
-          $exactWrapper.hide();
-          $penceWrapper.hide();
+          hideWrapper($exactWrapper);
+          hideWrapper($penceWrapper);
       }
     }
 

--- a/mtp_noms_ops/assets-src/stylesheets/views/_security-form-fields.scss
+++ b/mtp_noms_ops/assets-src/stylesheets/views/_security-form-fields.scss
@@ -151,16 +151,39 @@ select[disabled] {
     width: 100%;
   }
 
-  #id_card_number_last_digits, #id_sender_account_number, #id_sender_sort_code {
+  #id_card_number_last_digits, #id_sender_account_number, #id_sender_sort_code, #id_sender_ip_address {
     max-width: 226px;
     width: 100%;
   }
 
-  #id_card_number_last_digits-wrapper, #id_prisoner_name-wrapper, #id_prisoner_number-wrapper {
+  #id_card_number_last_digits-wrapper, #id_prisoner_name-wrapper, #id_prisoner_number-wrapper, #id_sender_ip_address-wrapper {
     width: 100%;
   }
 
   #id_prisoner_name-wrapper, #id_prisoner_number-wrapper {
     display: block;
+  }
+
+  .mtp-form-group-year {
+    max-width: 88px;
+    width: 100%;
+  }
+
+  .mtp-split-date-legend {
+    font-weight: bold;
+  }
+
+  .mtp-split-date-to-wrapper {
+    @include media(mobile) {
+      margin-top: 20px;
+    }
+  }
+
+  #id_amount_exact-wrapper,
+  #id_amount_pence-wrapper {
+    @extend .panel;
+    border-left-width: 5px;
+    margin-left: 18px;
+    padding-left: 26px;
   }
 }

--- a/mtp_noms_ops/templates/base.html
+++ b/mtp_noms_ops/templates/base.html
@@ -21,9 +21,9 @@
           {% if request.can_pre_approve %}
             {% include 'proposition-tab.html' with view_name='security:review_credits' subview_names='security:review_credits' link_text=_('New credits check') %}
           {% endif %}
-          {% include 'proposition-tab.html' with view_name='security:credit_list' subview_names='security:credit_list security:credit_detail security:credit_search_results' link_text=_('Credits') params=initial_params %}
-          {% include 'proposition-tab.html' with view_name='security:sender_list' subview_names='security:sender_list security:sender_detail security:sender_search_results' link_text=_('Payment sources') params=initial_params hide_on_mobile=True %}
-          {% include 'proposition-tab.html' with view_name='security:prisoner_list' subview_names='security:prisoner_list security:prisoner_detail security:prisoner_disbursement_detail security:prisoner_search_results' link_text=_('Prisoners') params=initial_params hide_on_mobile=True %}
+          {% include 'proposition-tab.html' with view_name='security:credit_list' subview_names='security:credit_list security:credit_detail security:credit_search_results security:credits_advanced_search' link_text=_('Credits') params=initial_params %}
+          {% include 'proposition-tab.html' with view_name='security:sender_list' subview_names='security:sender_list security:sender_detail security:sender_search_results security:senders_advanced_search' link_text=_('Payment sources') params=initial_params hide_on_mobile=True %}
+          {% include 'proposition-tab.html' with view_name='security:prisoner_list' subview_names='security:prisoner_list security:prisoner_detail security:prisoner_disbursement_detail security:prisoner_search_results  security:prisoners_advanced_search' link_text=_('Prisoners') params=initial_params hide_on_mobile=True %}
           {% include 'proposition-tab.html' with view_name='security:disbursement_list' subview_names='security:disbursement_list security:disbursement_detail security:disbursement_search_results' link_text=_('Disbursements') params=initial_params %}
           {% if request.can_access_notifications %}
             {% include 'proposition-tab.html' with view_name='security:notification_list' subview_names='security:notification_list' link_text=_('Notifications') %}

--- a/mtp_noms_ops/templates/security/credits_advanced_search.html
+++ b/mtp_noms_ops/templates/security/credits_advanced_search.html
@@ -1,0 +1,64 @@
+{% extends 'security/base_advanced_search.html' %}
+{% load i18n %}
+
+{% block advanced_search_fields %}
+  <div class="heading-large">{% trans 'Date received' %}</div>
+  <p>{% trans 'We only keep transaction data for 7 years.' %}
+
+  <div class="grid-row">
+    <div class="column-one-half">
+      {% include 'security/forms/split-date-field.html' with field=form.received_at__gte %}
+    </div>
+
+    <div class="column-one-half mtp-split-date-to-wrapper">
+      {% include 'security/forms/split-date-field.html' with field=form.received_at__lt %}
+    </div>
+  </div>
+
+  <div class="heading-large">{% trans 'Amounts' %}</div>
+  {% with field=form.amount_pattern choices=form.amount_pattern.field.choices %}
+    <fieldset>
+      <legend id="{{ field.id_for_label }}-label" class="visually-hidden">
+        <strong>{{ field.label }}</strong>
+      </legend>
+
+      <div class="{% if field.errors %}form-group-error{% endif %}">
+        {% for value, label in choices %}
+          <div class="multiple-choice">
+            <input id="{{ field.html_name }}-{{ value }}" type="radio" name="{{ field.html_name }}" value="{{ value }}" {% if value == field.value %}checked{% endif %}>
+            <label for="{{ field.html_name }}-{{ value }}">{{ label }}</label>
+          </div>
+
+          {% if value == 'exact' %}
+            {% include 'mtp_common/forms/field.html' with field=form.amount_exact only %}
+          {% endif %}
+
+          {% if value == 'pence' %}
+            {% include 'mtp_common/forms/field.html' with field=form.amount_pence only %}
+          {% endif %}
+        {% endfor %}
+      </div>
+    </fieldset>
+  {% endwith %}
+
+  <div class="heading-large">{% trans 'Payment methods' %}</div>
+  <div class="heading-medium">{% trans 'Payment source details' %}</div>
+  <p>{% trans 'Name, email and postcode are supplied by the payment source when they make a debit card payment. They are not validated.' %}
+  <p>{% trans 'When the payment source makes a bank transfer, the bank supplies the name on the bank account.' %}
+  {% include 'mtp_common/forms/field.html' with field=form.sender_name %}
+  {% include 'mtp_common/forms/field.html' with field=form.sender_email %}
+  {% include 'mtp_common/forms/field.html' with field=form.sender_postcode %}
+  {% include 'mtp_common/forms/field.html' with field=form.sender_ip_address %}
+
+  <div class="heading-medium">{% trans 'Debit card' %}</div>
+  {% include 'mtp_common/forms/field.html' with field=form.card_number_last_digits %}
+
+  <div class="heading-medium">{% trans 'Bank transfer' %}</div>
+  {% include 'mtp_common/forms/field.html' with field=form.sender_account_number %}
+  {% include 'mtp_common/forms/field.html' with field=form.sender_sort_code %}
+
+  <div class="heading-large">{% trans 'Prisoner' %}</div>
+  {% include 'mtp_common/forms/field.html' with field=form.prisoner_number %}
+  {% include 'mtp_common/forms/field.html' with field=form.prisoner_name %}
+
+{% endblock advanced_search_fields %}

--- a/mtp_noms_ops/templates/security/credits_list.html
+++ b/mtp_noms_ops/templates/security/credits_list.html
@@ -19,6 +19,10 @@
     <div class="grid-row">
         <div class="column-two-thirds">
           {% include 'security/forms/top-area-object-list.html' %}
+
+          {% if not is_search_results %}
+          <a href="{% url 'security:credits_advanced_search' %}">{% trans 'Advanced search' %}</a>
+          {% endif %}
         </div>
     </div>
 

--- a/mtp_noms_ops/templates/security/forms/split-date-field.html
+++ b/mtp_noms_ops/templates/security/forms/split-date-field.html
@@ -1,0 +1,24 @@
+{% load i18n %}
+
+<div class="{% if field.errors %}form-group-error{% endif %}">
+  <fieldset>
+    <legend class="form-label mtp-split-date-legend">{{ field.label }}</legend>
+    {% include 'mtp_common/forms/field-help-text.html' with field=field only %}
+    {% include 'mtp_common/forms/field-errors.html' with field=field only %}
+
+    <div class="form-date">
+      <div class="form-group mtp-form-group-day">
+        <label id="{{ field.auto_id }}_0-label" class="form-label" for="{{ field.auto_id }}_0">{% trans 'Day' %}</label>
+        <input class="form-control {% if field.errors %}form-control-error{% endif %}" id="{{ field.auto_id }}_0" name="{{ field.html_name }}_0" value="{{ field.value.0|default:'' }}" type="number" min="1" max="31">
+      </div>
+      <div class="form-group mtp-form-group-month">
+        <label id="{{ field.auto_id }}_1-label" class="form-label" for="{{ field.auto_id }}_1">{% trans 'Month' %}</label>
+        <input class="form-control {% if field.errors %}form-control-error{% endif %}" id="{{ field.auto_id }}_1" name="{{ field.html_name }}_1" value="{{ field.value.1|default:'' }}" type="number" min="1" max="12">
+      </div>
+      <div class="form-group mtp-form-group-year">
+        <label id="{{ field.auto_id }}_2-label" class="form-label" for="{{ field.auto_id }}_2">{% trans 'Year' %}</label>
+        <input class="form-control {% if field.errors %}form-control-error{% endif %}" id="{{ field.auto_id }}_2" name="{{ field.html_name }}_2" value="{{ field.value.2|default:'' }}" type="number" min="0" max="{% now 'Y' %}" data-era-boundary="{{ field.field.fields.2.era_boundary }}" >
+      </div>
+    </div>
+  </fieldset>
+</div>


### PR DESCRIPTION
This implements advanced search for credits.

Notes:
1. I created an `AmountSearchFormMixin` to keep the logic related to amount in one place instead of being a bit in the form, a bit in the enum.
2. I changed the show/hide javascript for amount pattern to support radio inputs as well.


### Screenshot

![localhost_8003_en-gb_security_credits_advanced-search_](https://user-images.githubusercontent.com/178865/62873307-12463800-bd17-11e9-904e-a2c8992c63d2.png)
