### PR TITLE
Add query string value mine for current user's prisons

### DIFF
--- a/mtp_noms_ops/apps/security/context_processors.py
+++ b/mtp_noms_ops/apps/security/context_processors.py
@@ -2,6 +2,8 @@ from urllib.parse import urlencode
 
 from django.contrib.auth import REDIRECT_FIELD_NAME
 
+from security import SEARCH_V2_FLAG
+from security.forms.object_base import YOUR_PRISONS_QUERY_STRING_VALUE
 from security.utils import can_choose_prisons, is_nomis_api_configured
 
 
@@ -18,8 +20,17 @@ def prison_choice_available(request):
 
 
 def initial_params(request):
+    user_flags = request.user.user_data.get('flags') or []
+    if SEARCH_V2_FLAG in user_flags:
+        return {
+            'initial_params': urlencode(
+                {'prison': YOUR_PRISONS_QUERY_STRING_VALUE},
+            ),
+        }
+
     if not request.user_prisons:
         return {}
+
     return {'initial_params': urlencode([
         ('prison', prison['nomis_id'])
         for prison in request.user_prisons
@@ -32,4 +43,5 @@ def common(_):
     """
     return {
         'REDIRECT_FIELD_NAME': REDIRECT_FIELD_NAME,
+        'YOUR_PRISONS_QUERY_STRING_VALUE': YOUR_PRISONS_QUERY_STRING_VALUE,
     }

--- a/mtp_noms_ops/apps/security/forms/object_list.py
+++ b/mtp_noms_ops/apps/security/forms/object_list.py
@@ -13,6 +13,7 @@ from security.forms.object_base import (
     get_credit_source_choices,
     get_disbursement_method_choices,
     parse_amount,
+    PrisonChoiceField,
     SecurityForm,
     validate_amount,
     validate_prisoner_number,
@@ -160,7 +161,6 @@ class BaseSendersForm(SecurityForm):
             ('-credit_total', _('Total sent (high to low)')),
         ]
     )
-    prison = forms.MultipleChoiceField(label=_('Prison'), required=False, choices=[])
 
     def get_object_list_endpoint_path(self):
         return '/senders/'
@@ -177,6 +177,7 @@ class SendersForm(BaseSendersForm):
 
     TODO: delete after search V2 goes live.
     """
+    prison = forms.MultipleChoiceField(label=_('Prison'), required=False, choices=[])
 
     prisoner_count__gte = forms.IntegerField(label=_('Number of prisoners (minimum)'), required=False, min_value=1)
     prisoner_count__lte = forms.IntegerField(label=_('Maximum prisoners sent to'), required=False, min_value=1)
@@ -281,6 +282,8 @@ class SendersFormV2(SearchFormV2Mixin, BaseSendersForm):
     """
     Search Form for Senders V2.
     """
+    prison = PrisonChoiceField(label=_('Prison'), required=False, choices=[])
+
     simple_search = forms.CharField(
         label=_('Search payment source name or email address'),
         required=False,
@@ -339,7 +342,6 @@ class BasePrisonersForm(SecurityForm):
             ('-prisoner_number', _('Prisoner number (Z to A)')),
         ],
     )
-    prison = forms.MultipleChoiceField(label=_('Prison'), required=False, choices=[])
 
     def get_object_list_endpoint_path(self):
         return '/prisoners/'
@@ -359,6 +361,7 @@ class PrisonersForm(BasePrisonersForm):
 
     TODO: delete after search V2 goes live.
     """
+    prison = forms.MultipleChoiceField(label=_('Prison'), required=False, choices=[])
 
     sender_count__gte = forms.IntegerField(label=_('Number of senders (minimum)'), required=False, min_value=1)
     sender_count__lte = forms.IntegerField(label=_('Maximum senders received from'), required=False, min_value=1)
@@ -447,6 +450,8 @@ class PrisonersFormV2(SearchFormV2Mixin, BasePrisonersForm):
     """
     Search Form for Prisoners V2.
     """
+    prison = PrisonChoiceField(label=_('Prison'), required=False)
+
     simple_search = forms.CharField(
         label=_('Search prisoner number or name'),
         required=False,
@@ -499,7 +504,6 @@ class BaseCreditsForm(SecurityForm):
             ('-prisoner_number', _('Prisoner number (Z to A)')),
         ],
     )
-    prison = forms.MultipleChoiceField(label=_('Prison'), required=False, choices=[])
 
     def get_object_list(self):
         object_list = super().get_object_list()
@@ -519,6 +523,7 @@ class CreditsForm(BaseCreditsForm):
 
     TODO: delete after search V2 goes live.
     """
+    prison = forms.MultipleChoiceField(label=_('Prison'), required=False, choices=[])
 
     received_at__gte = forms.DateField(label=_('Received since'), required=False,
                                        help_text=_('For example, 13/02/2018'))
@@ -665,6 +670,8 @@ class CreditsFormV2(SearchFormV2Mixin, AmountSearchFormMixin, BaseCreditsForm):
     """
     Search Form for Credits V2.
     """
+    prison = PrisonChoiceField(label=_('Prison'), required=False, choices=[])
+
     simple_search = forms.CharField(
         label=_('Search payment source name, email address or prisoner number'),
         required=False,
@@ -796,8 +803,6 @@ class BaseDisbursementsForm(SecurityForm):
         ],
     )
 
-    prison = forms.MultipleChoiceField(label=_('Prison'), required=False, choices=[])
-
     exclude_private_estate = True
 
     def get_object_list(self):
@@ -818,6 +823,8 @@ class DisbursementsForm(BaseDisbursementsForm):
 
     TODO: delete after search V2 goes live.
     """
+    prison = forms.MultipleChoiceField(label=_('Prison'), required=False, choices=[])
+
     created__gte = forms.DateField(label=_('Entered since'), help_text=_('For example, 13/02/2018'), required=False)
     created__lt = forms.DateField(label=_('Entered before'), help_text=_('For example, 13/02/2018'), required=False)
 
@@ -952,6 +959,8 @@ class DisbursementsFormV2(SearchFormV2Mixin, BaseDisbursementsForm):
     """
     Search Form for Disbursements V2.
     """
+    prison = PrisonChoiceField(label=_('Prison'), required=False, choices=[])
+
     simple_search = forms.CharField(
         label=_('Search recipient name or prisoner number'),
         required=False,

--- a/mtp_noms_ops/apps/security/tests/test_forms.py
+++ b/mtp_noms_ops/apps/security/tests/test_forms.py
@@ -333,6 +333,11 @@ class PrisonChoiceFieldTestCase(SimpleTestCase):
                 token=generate_tokens(),
             ),
         )
+        self.disable_cache = mock.patch('security.models.cache')
+        self.disable_cache.start().get.return_value = None
+
+    def tearDown(self):
+        self.disable_cache.stop()
 
     def test_configure(self):
         """

--- a/mtp_noms_ops/apps/security/tests/test_views.py
+++ b/mtp_noms_ops/apps/security/tests/test_views.py
@@ -23,6 +23,7 @@ from security import (
 )
 from security.models import EmailNotifications
 from security.tests import api_url, nomis_url, TEST_IMAGE_DATA
+from security.forms.object_base import YOUR_PRISONS_QUERY_STRING_VALUE
 from security.views.object_base import SEARCH_FORM_SUBMITTED_INPUT_NAME
 
 
@@ -603,11 +604,10 @@ class SearchV2SecurityTestCaseMixin:
             sample_prison_list(rsps=rsps)
             response = self.client.get(reverse(self.view_name))
 
-        for prison in user_prisons:
-            self.assertContains(
-                response,
-                f'<input type="hidden" name="prison" value="{prison["nomis_id"]}" />',
-            )
+        self.assertContains(
+            response,
+            f'<input type="hidden" name="prison" value="{YOUR_PRISONS_QUERY_STRING_VALUE}" />',
+        )
 
     def test_simple_search_redirects_to_search_results_page(self):
         """

--- a/mtp_noms_ops/templates/security/base_advanced_search.html
+++ b/mtp_noms_ops/templates/security/base_advanced_search.html
@@ -17,9 +17,7 @@
   <form class="mtp-security-advanced-search js-FormAnalytics" method="get">
     <input type="hidden" name="{{ form.advanced.html_name }}" value="True" />
     <input type="hidden" name="{{ search_form_submitted_input_name }}" value="1" />
-  {% for prison in request.user_prisons %}
-    <input type="hidden" name="prison" value="{{ prison.nomis_id }}" />
-  {% endfor %}
+    <input type="hidden" name="prison" value="{{ YOUR_PRISONS_QUERY_STRING_VALUE }}" />
 
     <div class="grid-row">
       <div class="column-two-thirds">

--- a/mtp_noms_ops/templates/security/forms/top-area-object-list.html
+++ b/mtp_noms_ops/templates/security/forms/top-area-object-list.html
@@ -34,9 +34,7 @@
     <input type="hidden" name="{{ search_form_submitted_input_name }}" value="1" />
     {{ form.ordering.as_hidden }}
 
-    {% for prison in request.user_prisons %}
-        <input type="hidden" name="prison" value="{{ prison.nomis_id }}" />
-    {% endfor %}
+    <input type="hidden" name="prison" value="{{ YOUR_PRISONS_QUERY_STRING_VALUE }}" />
 
     {% with field=form.simple_search %}
       <div id="{{ field.id_for_label }}-wrapper" class="form-group {% if field.errors %}form-group-error{% endif %}">


### PR DESCRIPTION
This adds a new special value `mine` to the list of allowed choices for the query param `prison` in search forms V2.

The value is then automatically expanded into the current user's prisons when making API calls.