### PR TITLE
Prison selector in search forms V2

### DIFF
--- a/mtp_noms_ops/apps/security/context_processors.py
+++ b/mtp_noms_ops/apps/security/context_processors.py
@@ -2,6 +2,8 @@ from urllib.parse import urlencode
 
 from django.contrib.auth import REDIRECT_FIELD_NAME
 
+from security import SEARCH_V2_FLAG
+from security.forms.object_list import YOUR_PRISONS_QUERY_STRING_VALUE
 from security.utils import can_choose_prisons, is_nomis_api_configured
 
 
@@ -18,8 +20,17 @@ def prison_choice_available(request):
 
 
 def initial_params(request):
+    user_flags = request.user.user_data.get('flags') or []
+    if SEARCH_V2_FLAG in user_flags:
+        return {
+            'initial_params': urlencode(
+                {'prison_selector': YOUR_PRISONS_QUERY_STRING_VALUE},
+            ),
+        }
+
     if not request.user_prisons:
         return {}
+
     return {'initial_params': urlencode([
         ('prison', prison['nomis_id'])
         for prison in request.user_prisons
@@ -32,4 +43,5 @@ def common(_):
     """
     return {
         'REDIRECT_FIELD_NAME': REDIRECT_FIELD_NAME,
+        'YOUR_PRISONS_QUERY_STRING_VALUE': YOUR_PRISONS_QUERY_STRING_VALUE,
     }

--- a/mtp_noms_ops/apps/security/context_processors.py
+++ b/mtp_noms_ops/apps/security/context_processors.py
@@ -3,7 +3,7 @@ from urllib.parse import urlencode
 from django.contrib.auth import REDIRECT_FIELD_NAME
 
 from security import SEARCH_V2_FLAG
-from security.forms.object_list import YOUR_PRISONS_QUERY_STRING_VALUE
+from security.forms.object_list import PRISON_SELECTOR_USER_PRISONS_CHOICE_VALUE
 from security.utils import can_choose_prisons, is_nomis_api_configured
 
 
@@ -24,7 +24,7 @@ def initial_params(request):
     if SEARCH_V2_FLAG in user_flags:
         return {
             'initial_params': urlencode(
-                {'prison_selector': YOUR_PRISONS_QUERY_STRING_VALUE},
+                {'prison_selector': PRISON_SELECTOR_USER_PRISONS_CHOICE_VALUE},
             ),
         }
 
@@ -43,5 +43,5 @@ def common(_):
     """
     return {
         'REDIRECT_FIELD_NAME': REDIRECT_FIELD_NAME,
-        'YOUR_PRISONS_QUERY_STRING_VALUE': YOUR_PRISONS_QUERY_STRING_VALUE,
+        'PRISON_SELECTOR_USER_PRISONS_CHOICE_VALUE': PRISON_SELECTOR_USER_PRISONS_CHOICE_VALUE,
     }

--- a/mtp_noms_ops/apps/security/forms/object_list.py
+++ b/mtp_noms_ops/apps/security/forms/object_list.py
@@ -241,7 +241,6 @@ class BaseSendersForm(SecurityForm):
             ('-credit_total', _('Total sent (high to low)')),
         ]
     )
-    prison = forms.MultipleChoiceField(label=_('Prison'), required=False, choices=[])
 
     def get_object_list_endpoint_path(self):
         return '/senders/'
@@ -258,6 +257,7 @@ class SendersForm(BaseSendersForm):
 
     TODO: delete after search V2 goes live.
     """
+    prison = forms.MultipleChoiceField(label=_('Prison'), required=False, choices=[])
 
     prisoner_count__gte = forms.IntegerField(label=_('Number of prisoners (minimum)'), required=False, min_value=1)
     prisoner_count__lte = forms.IntegerField(label=_('Maximum prisoners sent to'), required=False, min_value=1)
@@ -358,7 +358,7 @@ class SendersForm(BaseSendersForm):
         return query_data
 
 
-class SendersFormV2(SearchFormV2Mixin, BaseSendersForm):
+class SendersFormV2(SearchFormV2Mixin, PrisonSelectorSearchFormMixin, BaseSendersForm):
     """
     Search Form for Senders V2.
     """
@@ -420,7 +420,6 @@ class BasePrisonersForm(SecurityForm):
             ('-prisoner_number', _('Prisoner number (Z to A)')),
         ],
     )
-    prison = forms.MultipleChoiceField(label=_('Prison'), required=False, choices=[])
 
     def get_object_list_endpoint_path(self):
         return '/prisoners/'
@@ -440,6 +439,7 @@ class PrisonersForm(BasePrisonersForm):
 
     TODO: delete after search V2 goes live.
     """
+    prison = forms.MultipleChoiceField(label=_('Prison'), required=False, choices=[])
 
     sender_count__gte = forms.IntegerField(label=_('Number of senders (minimum)'), required=False, min_value=1)
     sender_count__lte = forms.IntegerField(label=_('Maximum senders received from'), required=False, min_value=1)
@@ -524,7 +524,7 @@ class PrisonersForm(BasePrisonersForm):
         return query_data
 
 
-class PrisonersFormV2(SearchFormV2Mixin, BasePrisonersForm):
+class PrisonersFormV2(SearchFormV2Mixin, PrisonSelectorSearchFormMixin, BasePrisonersForm):
     """
     Search Form for Prisoners V2.
     """
@@ -580,7 +580,6 @@ class BaseCreditsForm(SecurityForm):
             ('-prisoner_number', _('Prisoner number (Z to A)')),
         ],
     )
-    prison = forms.MultipleChoiceField(label=_('Prison'), required=False, choices=[])
 
     def get_object_list(self):
         object_list = super().get_object_list()
@@ -600,6 +599,7 @@ class CreditsForm(BaseCreditsForm):
 
     TODO: delete after search V2 goes live.
     """
+    prison = forms.MultipleChoiceField(label=_('Prison'), required=False, choices=[])
 
     received_at__gte = forms.DateField(label=_('Received since'), required=False,
                                        help_text=_('For example, 13/02/2018'))
@@ -742,7 +742,12 @@ class CreditsForm(BaseCreditsForm):
         return str(description).lower() if description else None
 
 
-class CreditsFormV2(SearchFormV2Mixin, AmountSearchFormMixin, BaseCreditsForm):
+class CreditsFormV2(
+    SearchFormV2Mixin,
+    AmountSearchFormMixin,
+    PrisonSelectorSearchFormMixin,
+    BaseCreditsForm,
+):
     """
     Search Form for Credits V2.
     """
@@ -877,8 +882,6 @@ class BaseDisbursementsForm(SecurityForm):
         ],
     )
 
-    prison = forms.MultipleChoiceField(label=_('Prison'), required=False, choices=[])
-
     exclude_private_estate = True
 
     def get_object_list(self):
@@ -899,6 +902,8 @@ class DisbursementsForm(BaseDisbursementsForm):
 
     TODO: delete after search V2 goes live.
     """
+    prison = forms.MultipleChoiceField(label=_('Prison'), required=False, choices=[])
+
     created__gte = forms.DateField(label=_('Entered since'), help_text=_('For example, 13/02/2018'), required=False)
     created__lt = forms.DateField(label=_('Entered before'), help_text=_('For example, 13/02/2018'), required=False)
 
@@ -1029,7 +1034,12 @@ class DisbursementsForm(BaseDisbursementsForm):
         return str(description).lower() if description else None
 
 
-class DisbursementsFormV2(SearchFormV2Mixin, AmountSearchFormMixin, BaseDisbursementsForm):
+class DisbursementsFormV2(
+    SearchFormV2Mixin,
+    AmountSearchFormMixin,
+    PrisonSelectorSearchFormMixin,
+    BaseDisbursementsForm,
+):
     """
     Search Form for Disbursements V2.
     """

--- a/mtp_noms_ops/apps/security/forms/object_list.py
+++ b/mtp_noms_ops/apps/security/forms/object_list.py
@@ -25,7 +25,7 @@ from security.utils import (
     sender_profile_name,
 )
 
-YOUR_PRISONS_QUERY_STRING_VALUE = 'mine'
+PRISON_SELECTOR_USER_PRISONS_CHOICE_VALUE = 'mine'
 
 END_DATE_BEFORE_START_DATE_ERROR_MSG = _('Must be after the start date.')
 
@@ -69,11 +69,11 @@ class PrisonSelectorSearchFormMixin(forms.Form):
         label=_('Choose a prison'),
         required=False,
         choices=(
-            (YOUR_PRISONS_QUERY_STRING_VALUE, _('Your prisons')),
+            (PRISON_SELECTOR_USER_PRISONS_CHOICE_VALUE, _('Your prisons')),
             (PRISON_SELECTOR_ALL_PRISONS_CHOICE_VALUE, _('All prisons')),
             (PRISON_SELECTOR_EXACT_PRISON_CHOICE_VALUE, _('A specific prison')),
         ),
-        initial=YOUR_PRISONS_QUERY_STRING_VALUE,
+        initial=PRISON_SELECTOR_USER_PRISONS_CHOICE_VALUE,
     )
     prison = forms.MultipleChoiceField(label=_('Prison name'), required=False, choices=[])
 
@@ -81,7 +81,7 @@ class PrisonSelectorSearchFormMixin(forms.Form):
         prison_selector = query_data.pop('prison_selector', None)
         prisons = query_data.pop('prison', [])
 
-        if prison_selector == YOUR_PRISONS_QUERY_STRING_VALUE:
+        if prison_selector == PRISON_SELECTOR_USER_PRISONS_CHOICE_VALUE:
             if self.request.user_prisons:
                 query_data['prison'] = [
                     prison['nomis_id']

--- a/mtp_noms_ops/apps/security/forms/object_list.py
+++ b/mtp_noms_ops/apps/security/forms/object_list.py
@@ -63,13 +63,14 @@ class PrisonSelectorSearchFormMixin(forms.Form):
     when prison_selector != exact, any `prison` value is reset as not applicable
     """
     PRISON_SELECTOR_EXACT_PRISON_CHOICE_VALUE = 'exact'
+    PRISON_SELECTOR_ALL_PRISONS_CHOICE_VALUE = 'all'
 
     prison_selector = forms.ChoiceField(
         label=_('Choose a prison'),
         required=False,
         choices=(
             (YOUR_PRISONS_QUERY_STRING_VALUE, _('Your prisons')),
-            ('all', _('All prisons')),
+            (PRISON_SELECTOR_ALL_PRISONS_CHOICE_VALUE, _('All prisons')),
             (PRISON_SELECTOR_EXACT_PRISON_CHOICE_VALUE, _('A specific prison')),
         ),
         initial=YOUR_PRISONS_QUERY_STRING_VALUE,

--- a/mtp_noms_ops/apps/security/tests/test_forms.py
+++ b/mtp_noms_ops/apps/security/tests/test_forms.py
@@ -17,12 +17,12 @@ from security.forms.object_list import (
     CreditsFormV2,
     DisbursementsForm,
     DisbursementsFormV2,
+    PRISON_SELECTOR_USER_PRISONS_CHOICE_VALUE,
     PrisonersForm,
     PrisonersFormV2,
     PrisonSelectorSearchFormMixin,
     SendersForm,
     SendersFormV2,
-    YOUR_PRISONS_QUERY_STRING_VALUE,
 )
 from security.forms.review import ReviewCreditsForm
 from security.tests import api_url
@@ -356,19 +356,19 @@ class PrisonSelectorSearchFormMixinTestCase(SimpleTestCase):
                 Scenario(
                     [SAMPLE_PRISONS[0]],
                     {
-                        'prison_selector': YOUR_PRISONS_QUERY_STRING_VALUE,
+                        'prison_selector': PRISON_SELECTOR_USER_PRISONS_CHOICE_VALUE,
                         'prison': [SAMPLE_PRISONS[1]['nomis_id']],
                     },
                     {
                         'page': 1,
-                        'prison_selector': YOUR_PRISONS_QUERY_STRING_VALUE,
+                        'prison_selector': PRISON_SELECTOR_USER_PRISONS_CHOICE_VALUE,
                         'prison': [],  # reset
                     },
                     {
                         'prison': [SAMPLE_PRISONS[0]['nomis_id']],
                     },
                     {
-                        'prison_selector': [YOUR_PRISONS_QUERY_STRING_VALUE],
+                        'prison_selector': [PRISON_SELECTOR_USER_PRISONS_CHOICE_VALUE],
                     },
                 ),
 
@@ -376,17 +376,17 @@ class PrisonSelectorSearchFormMixinTestCase(SimpleTestCase):
                 Scenario(
                     [],
                     {
-                        'prison_selector': YOUR_PRISONS_QUERY_STRING_VALUE,
+                        'prison_selector': PRISON_SELECTOR_USER_PRISONS_CHOICE_VALUE,
                         'prison': [SAMPLE_PRISONS[1]['nomis_id']],
                     },
                     {
                         'page': 1,
-                        'prison_selector': YOUR_PRISONS_QUERY_STRING_VALUE,
+                        'prison_selector': PRISON_SELECTOR_USER_PRISONS_CHOICE_VALUE,
                         'prison': [],  # reset
                     },
                     {},  # expected api query params empty because we don't want to filter by any prison
                     {
-                        'prison_selector': [YOUR_PRISONS_QUERY_STRING_VALUE],
+                        'prison_selector': [PRISON_SELECTOR_USER_PRISONS_CHOICE_VALUE],
                     },
                 ),
 
@@ -691,7 +691,7 @@ class SenderFormV2TestCase(SecurityFormTestCase):
                     'offset': ['0'],
                     'limit': ['20'],
                     'ordering': ['-prisoner_count'],
-                    'prison': [  # YOUR_PRISONS_QUERY_STRING_VALUE expands into user prisons
+                    'prison': [  # PRISON_SELECTOR_USER_PRISONS_CHOICE_VALUE expands into user prisons
                         prison['nomis_id']
                         for prison in self.user_prisons
                     ],
@@ -704,7 +704,7 @@ class SenderFormV2TestCase(SecurityFormTestCase):
                 'page': 1,
                 'ordering': '-prisoner_count',
                 'prison': [],
-                'prison_selector': YOUR_PRISONS_QUERY_STRING_VALUE,
+                'prison_selector': PRISON_SELECTOR_USER_PRISONS_CHOICE_VALUE,
                 'advanced': False,
                 'simple_search': '',
                 'sender_name': '',
@@ -720,7 +720,7 @@ class SenderFormV2TestCase(SecurityFormTestCase):
             {
                 'advanced': ['False'],
                 'ordering': ['-prisoner_count'],
-                'prison_selector': [YOUR_PRISONS_QUERY_STRING_VALUE],
+                'prison_selector': [PRISON_SELECTOR_USER_PRISONS_CHOICE_VALUE],
             },
         )
 
@@ -737,7 +737,7 @@ class SenderFormV2TestCase(SecurityFormTestCase):
                 data={
                     'page': 2,
                     'ordering': '-credit_total',
-                    'prison_selection': YOUR_PRISONS_QUERY_STRING_VALUE,
+                    'prison_selection': PRISON_SELECTOR_USER_PRISONS_CHOICE_VALUE,
                     'simple_search': 'Joh',
                 },
             )
@@ -752,7 +752,7 @@ class SenderFormV2TestCase(SecurityFormTestCase):
                     'limit': ['20'],
                     'ordering': ['-credit_total'],
                     'simple_search': ['Joh'],
-                    'prison': [  # YOUR_PRISONS_QUERY_STRING_VALUE expands into user prisons
+                    'prison': [  # PRISON_SELECTOR_USER_PRISONS_CHOICE_VALUE expands into user prisons
                         prison['nomis_id']
                         for prison in self.user_prisons
                     ],
@@ -766,7 +766,7 @@ class SenderFormV2TestCase(SecurityFormTestCase):
                 'card_number_last_digits': '',
                 'page': 2,
                 'ordering': '-credit_total',
-                'prison_selector': YOUR_PRISONS_QUERY_STRING_VALUE,
+                'prison_selector': PRISON_SELECTOR_USER_PRISONS_CHOICE_VALUE,
                 'prison': [],
                 'sender_account_number': '',
                 'sender_email': '',
@@ -782,7 +782,7 @@ class SenderFormV2TestCase(SecurityFormTestCase):
             {
                 'advanced': ['False'],
                 'ordering': ['-credit_total'],
-                'prison_selector': [YOUR_PRISONS_QUERY_STRING_VALUE],
+                'prison_selector': [PRISON_SELECTOR_USER_PRISONS_CHOICE_VALUE],
                 'simple_search': ['Joh'],
             },
         )
@@ -800,7 +800,7 @@ class SenderFormV2TestCase(SecurityFormTestCase):
                 data={
                     'page': 2,
                     'ordering': '-credit_total',
-                    'prison_selector': YOUR_PRISONS_QUERY_STRING_VALUE,
+                    'prison_selector': PRISON_SELECTOR_USER_PRISONS_CHOICE_VALUE,
                     'advanced': True,
                     'sender_name': 'John Doe',
                     'sender_email': 'johndoe',
@@ -821,7 +821,7 @@ class SenderFormV2TestCase(SecurityFormTestCase):
                     'offset': ['20'],
                     'limit': ['20'],
                     'ordering': ['-credit_total'],
-                    'prison': [  # YOUR_PRISONS_QUERY_STRING_VALUE expands into user prisons
+                    'prison': [  # PRISON_SELECTOR_USER_PRISONS_CHOICE_VALUE expands into user prisons
                         prison['nomis_id']
                         for prison in self.user_prisons
                     ],
@@ -841,7 +841,7 @@ class SenderFormV2TestCase(SecurityFormTestCase):
                 'advanced': True,
                 'page': 2,
                 'ordering': '-credit_total',
-                'prison_selector': YOUR_PRISONS_QUERY_STRING_VALUE,
+                'prison_selector': PRISON_SELECTOR_USER_PRISONS_CHOICE_VALUE,
                 'prison': [],
                 'sender_name': 'John Doe',
                 'sender_email': 'johndoe',
@@ -856,7 +856,7 @@ class SenderFormV2TestCase(SecurityFormTestCase):
             parse_qs(form.query_string),
             {
                 'ordering': ['-credit_total'],
-                'prison_selector': [YOUR_PRISONS_QUERY_STRING_VALUE],
+                'prison_selector': [PRISON_SELECTOR_USER_PRISONS_CHOICE_VALUE],
                 'advanced': ['True'],
                 'sender_name': ['John Doe'],
                 'sender_email': ['johndoe'],
@@ -997,7 +997,7 @@ class PrisonerFormV2TestCase(SecurityFormTestCase):
                     'offset': ['0'],
                     'limit': ['20'],
                     'ordering': ['-sender_count'],
-                    'prison': [  # YOUR_PRISONS_QUERY_STRING_VALUE expands into user prisons
+                    'prison': [  # PRISON_SELECTOR_USER_PRISONS_CHOICE_VALUE expands into user prisons
                         prison['nomis_id']
                         for prison in self.user_prisons
                     ],
@@ -1010,7 +1010,7 @@ class PrisonerFormV2TestCase(SecurityFormTestCase):
                 'page': 1,
                 'ordering': '-sender_count',
                 'prison': [],
-                'prison_selector': YOUR_PRISONS_QUERY_STRING_VALUE,
+                'prison_selector': PRISON_SELECTOR_USER_PRISONS_CHOICE_VALUE,
                 'simple_search': '',
                 'advanced': False,
                 'prisoner_name': '',
@@ -1022,7 +1022,7 @@ class PrisonerFormV2TestCase(SecurityFormTestCase):
             {
                 'advanced': ['False'],
                 'ordering': ['-sender_count'],
-                'prison_selector': [YOUR_PRISONS_QUERY_STRING_VALUE],
+                'prison_selector': [PRISON_SELECTOR_USER_PRISONS_CHOICE_VALUE],
             },
         )
 
@@ -1039,7 +1039,7 @@ class PrisonerFormV2TestCase(SecurityFormTestCase):
                 data={
                     'page': 2,
                     'ordering': '-credit_total',
-                    'prison_selection': YOUR_PRISONS_QUERY_STRING_VALUE,
+                    'prison_selection': PRISON_SELECTOR_USER_PRISONS_CHOICE_VALUE,
                     'simple_search': 'Joh',
                 },
             )
@@ -1054,7 +1054,7 @@ class PrisonerFormV2TestCase(SecurityFormTestCase):
                     'limit': ['20'],
                     'ordering': ['-credit_total'],
                     'simple_search': ['Joh'],
-                    'prison': [  # YOUR_PRISONS_QUERY_STRING_VALUE expands into user prisons
+                    'prison': [  # PRISON_SELECTOR_USER_PRISONS_CHOICE_VALUE expands into user prisons
                         prison['nomis_id']
                         for prison in self.user_prisons
                     ],
@@ -1067,7 +1067,7 @@ class PrisonerFormV2TestCase(SecurityFormTestCase):
                 'advanced': False,
                 'page': 2,
                 'ordering': '-credit_total',
-                'prison_selector': YOUR_PRISONS_QUERY_STRING_VALUE,
+                'prison_selector': PRISON_SELECTOR_USER_PRISONS_CHOICE_VALUE,
                 'prison': [],
                 'simple_search': 'Joh',
                 'prisoner_name': '',
@@ -1080,7 +1080,7 @@ class PrisonerFormV2TestCase(SecurityFormTestCase):
             {
                 'advanced': ['False'],
                 'ordering': ['-credit_total'],
-                'prison_selector': [YOUR_PRISONS_QUERY_STRING_VALUE],
+                'prison_selector': [PRISON_SELECTOR_USER_PRISONS_CHOICE_VALUE],
                 'simple_search': ['Joh'],
             },
         )
@@ -1098,7 +1098,7 @@ class PrisonerFormV2TestCase(SecurityFormTestCase):
                 data={
                     'page': 2,
                     'ordering': '-credit_total',
-                    'prison_selector': YOUR_PRISONS_QUERY_STRING_VALUE,
+                    'prison_selector': PRISON_SELECTOR_USER_PRISONS_CHOICE_VALUE,
                     'advanced': True,
                     'prisoner_name': 'John Doe',
                     'prisoner_number': 'a2624ae',
@@ -1114,7 +1114,7 @@ class PrisonerFormV2TestCase(SecurityFormTestCase):
                     'offset': ['20'],
                     'limit': ['20'],
                     'ordering': ['-credit_total'],
-                    'prison': [  # YOUR_PRISONS_QUERY_STRING_VALUE expands into user prisons
+                    'prison': [  # PRISON_SELECTOR_USER_PRISONS_CHOICE_VALUE expands into user prisons
                         prison['nomis_id']
                         for prison in self.user_prisons
                     ],
@@ -1129,7 +1129,7 @@ class PrisonerFormV2TestCase(SecurityFormTestCase):
                 'advanced': True,
                 'page': 2,
                 'ordering': '-credit_total',
-                'prison_selector': YOUR_PRISONS_QUERY_STRING_VALUE,
+                'prison_selector': PRISON_SELECTOR_USER_PRISONS_CHOICE_VALUE,
                 'prison': [],
                 'simple_search': '',
                 'prisoner_name': 'John Doe',
@@ -1141,7 +1141,7 @@ class PrisonerFormV2TestCase(SecurityFormTestCase):
             parse_qs(form.query_string),
             {
                 'ordering': ['-credit_total'],
-                'prison_selector': [YOUR_PRISONS_QUERY_STRING_VALUE],
+                'prison_selector': [PRISON_SELECTOR_USER_PRISONS_CHOICE_VALUE],
                 'advanced': ['True'],
                 'prisoner_name': ['John Doe'],
                 'prisoner_number': ['A2624AE'],
@@ -1284,7 +1284,7 @@ class CreditFormV2TestCase(SecurityFormTestCase):
                     'offset': ['0'],
                     'limit': ['20'],
                     'ordering': ['-received_at'],
-                    'prison': [  # YOUR_PRISONS_QUERY_STRING_VALUE expands into user prisons
+                    'prison': [  # PRISON_SELECTOR_USER_PRISONS_CHOICE_VALUE expands into user prisons
                         prison['nomis_id']
                         for prison in self.user_prisons
                     ],
@@ -1297,7 +1297,7 @@ class CreditFormV2TestCase(SecurityFormTestCase):
                 'page': 1,
                 'ordering': '-received_at',
                 'prison': [],
-                'prison_selector': YOUR_PRISONS_QUERY_STRING_VALUE,
+                'prison_selector': PRISON_SELECTOR_USER_PRISONS_CHOICE_VALUE,
                 'simple_search': '',
                 'advanced': False,
                 'amount_pattern': '',
@@ -1321,7 +1321,7 @@ class CreditFormV2TestCase(SecurityFormTestCase):
             {
                 'advanced': ['False'],
                 'ordering': ['-received_at'],
-                'prison_selector': [YOUR_PRISONS_QUERY_STRING_VALUE],
+                'prison_selector': [PRISON_SELECTOR_USER_PRISONS_CHOICE_VALUE],
             },
         )
 
@@ -1338,7 +1338,7 @@ class CreditFormV2TestCase(SecurityFormTestCase):
                 data={
                     'page': 2,
                     'ordering': '-amount',
-                    'prison_selection': YOUR_PRISONS_QUERY_STRING_VALUE,
+                    'prison_selection': PRISON_SELECTOR_USER_PRISONS_CHOICE_VALUE,
                     'simple_search': 'Joh',
                 },
             )
@@ -1353,7 +1353,7 @@ class CreditFormV2TestCase(SecurityFormTestCase):
                     'limit': ['20'],
                     'ordering': ['-amount'],
                     'simple_search': ['Joh'],
-                    'prison': [  # YOUR_PRISONS_QUERY_STRING_VALUE expands into user prisons
+                    'prison': [  # PRISON_SELECTOR_USER_PRISONS_CHOICE_VALUE expands into user prisons
                         prison['nomis_id']
                         for prison in self.user_prisons
                     ],
@@ -1366,7 +1366,7 @@ class CreditFormV2TestCase(SecurityFormTestCase):
                 'advanced': False,
                 'page': 2,
                 'ordering': '-amount',
-                'prison_selector': YOUR_PRISONS_QUERY_STRING_VALUE,
+                'prison_selector': PRISON_SELECTOR_USER_PRISONS_CHOICE_VALUE,
                 'prison': [],
                 'simple_search': 'Joh',
                 'amount_pattern': '',
@@ -1391,7 +1391,7 @@ class CreditFormV2TestCase(SecurityFormTestCase):
             {
                 'advanced': ['False'],
                 'ordering': ['-amount'],
-                'prison_selector': [YOUR_PRISONS_QUERY_STRING_VALUE],
+                'prison_selector': [PRISON_SELECTOR_USER_PRISONS_CHOICE_VALUE],
                 'simple_search': ['Joh'],
             },
         )
@@ -1409,7 +1409,7 @@ class CreditFormV2TestCase(SecurityFormTestCase):
                 data={
                     'page': 2,
                     'ordering': '-amount',
-                    'prison_selector': YOUR_PRISONS_QUERY_STRING_VALUE,
+                    'prison_selector': PRISON_SELECTOR_USER_PRISONS_CHOICE_VALUE,
                     'advanced': True,
                     'amount_pattern': AmountPattern.exact.name,
                     'amount_exact': '100.00',
@@ -1442,7 +1442,7 @@ class CreditFormV2TestCase(SecurityFormTestCase):
                     'offset': ['20'],
                     'limit': ['20'],
                     'ordering': ['-amount'],
-                    'prison': [  # YOUR_PRISONS_QUERY_STRING_VALUE expands into user prisons
+                    'prison': [  # PRISON_SELECTOR_USER_PRISONS_CHOICE_VALUE expands into user prisons
                         prison['nomis_id']
                         for prison in self.user_prisons
                     ],
@@ -1467,7 +1467,7 @@ class CreditFormV2TestCase(SecurityFormTestCase):
                 'advanced': True,
                 'page': 2,
                 'ordering': '-amount',
-                'prison_selector': YOUR_PRISONS_QUERY_STRING_VALUE,
+                'prison_selector': PRISON_SELECTOR_USER_PRISONS_CHOICE_VALUE,
                 'prison': [],
                 'simple_search': '',
                 'amount_pattern': AmountPattern.exact.name,
@@ -1492,7 +1492,7 @@ class CreditFormV2TestCase(SecurityFormTestCase):
             parse_qs(form.query_string),
             {
                 'ordering': ['-amount'],
-                'prison_selector': [YOUR_PRISONS_QUERY_STRING_VALUE],
+                'prison_selector': [PRISON_SELECTOR_USER_PRISONS_CHOICE_VALUE],
                 'amount_pattern': ['exact'],
                 'amount_exact': ['100.00'],
                 'advanced': ['True'],
@@ -1685,7 +1685,7 @@ class DisbursementFormV2TestCase(SecurityFormTestCase):
                     'offset': ['0'],
                     'limit': ['20'],
                     'ordering': ['-created'],
-                    'prison': [  # YOUR_PRISONS_QUERY_STRING_VALUE expands into user prisons
+                    'prison': [  # PRISON_SELECTOR_USER_PRISONS_CHOICE_VALUE expands into user prisons
                         prison['nomis_id']
                         for prison in self.user_prisons
                     ],
@@ -1698,7 +1698,7 @@ class DisbursementFormV2TestCase(SecurityFormTestCase):
                 'page': 1,
                 'ordering': '-created',
                 'prison': [],
-                'prison_selector': YOUR_PRISONS_QUERY_STRING_VALUE,
+                'prison_selector': PRISON_SELECTOR_USER_PRISONS_CHOICE_VALUE,
                 'simple_search': '',
                 'advanced': False,
                 'amount_exact': '',
@@ -1721,7 +1721,7 @@ class DisbursementFormV2TestCase(SecurityFormTestCase):
             {
                 'advanced': ['False'],
                 'ordering': ['-created'],
-                'prison_selector': [YOUR_PRISONS_QUERY_STRING_VALUE],
+                'prison_selector': [PRISON_SELECTOR_USER_PRISONS_CHOICE_VALUE],
             },
         )
 
@@ -1738,7 +1738,7 @@ class DisbursementFormV2TestCase(SecurityFormTestCase):
                 data={
                     'page': 2,
                     'ordering': '-amount',
-                    'prison_selection': YOUR_PRISONS_QUERY_STRING_VALUE,
+                    'prison_selection': PRISON_SELECTOR_USER_PRISONS_CHOICE_VALUE,
                     'simple_search': 'Joh',
                 },
             )
@@ -1753,7 +1753,7 @@ class DisbursementFormV2TestCase(SecurityFormTestCase):
                     'limit': ['20'],
                     'ordering': ['-amount'],
                     'simple_search': ['Joh'],
-                    'prison': [  # YOUR_PRISONS_QUERY_STRING_VALUE expands into user prisons
+                    'prison': [  # PRISON_SELECTOR_USER_PRISONS_CHOICE_VALUE expands into user prisons
                         prison['nomis_id']
                         for prison in self.user_prisons
                     ],
@@ -1766,7 +1766,7 @@ class DisbursementFormV2TestCase(SecurityFormTestCase):
                 'advanced': False,
                 'page': 2,
                 'ordering': '-amount',
-                'prison_selector': YOUR_PRISONS_QUERY_STRING_VALUE,
+                'prison_selector': PRISON_SELECTOR_USER_PRISONS_CHOICE_VALUE,
                 'prison': [],
                 'simple_search': 'Joh',
                 'amount_exact': '',
@@ -1790,7 +1790,7 @@ class DisbursementFormV2TestCase(SecurityFormTestCase):
             {
                 'advanced': ['False'],
                 'ordering': ['-amount'],
-                'prison_selector': [YOUR_PRISONS_QUERY_STRING_VALUE],
+                'prison_selector': [PRISON_SELECTOR_USER_PRISONS_CHOICE_VALUE],
                 'simple_search': ['Joh'],
             },
         )
@@ -1808,7 +1808,7 @@ class DisbursementFormV2TestCase(SecurityFormTestCase):
                 data={
                     'page': 2,
                     'ordering': '-amount',
-                    'prison_selector': YOUR_PRISONS_QUERY_STRING_VALUE,
+                    'prison_selector': PRISON_SELECTOR_USER_PRISONS_CHOICE_VALUE,
                     'advanced': True,
                     'amount_pattern': AmountPattern.exact.name,
                     'amount_exact': '100.00',
@@ -1840,7 +1840,7 @@ class DisbursementFormV2TestCase(SecurityFormTestCase):
                     'offset': ['20'],
                     'limit': ['20'],
                     'ordering': ['-amount'],
-                    'prison': [  # YOUR_PRISONS_QUERY_STRING_VALUE expands into user prisons
+                    'prison': [  # PRISON_SELECTOR_USER_PRISONS_CHOICE_VALUE expands into user prisons
                         prison['nomis_id']
                         for prison in self.user_prisons
                     ],
@@ -1864,7 +1864,7 @@ class DisbursementFormV2TestCase(SecurityFormTestCase):
                 'advanced': True,
                 'page': 2,
                 'ordering': '-amount',
-                'prison_selector': YOUR_PRISONS_QUERY_STRING_VALUE,
+                'prison_selector': PRISON_SELECTOR_USER_PRISONS_CHOICE_VALUE,
                 'prison': [],
                 'simple_search': '',
                 'amount_pattern': AmountPattern.exact.name,
@@ -1888,7 +1888,7 @@ class DisbursementFormV2TestCase(SecurityFormTestCase):
             parse_qs(form.query_string),
             {
                 'ordering': ['-amount'],
-                'prison_selector': [YOUR_PRISONS_QUERY_STRING_VALUE],
+                'prison_selector': [PRISON_SELECTOR_USER_PRISONS_CHOICE_VALUE],
                 'amount_pattern': ['exact'],
                 'amount_exact': ['100.00'],
                 'advanced': ['True'],

--- a/mtp_noms_ops/apps/security/tests/test_forms.py
+++ b/mtp_noms_ops/apps/security/tests/test_forms.py
@@ -394,17 +394,17 @@ class PrisonSelectorSearchFormMixinTestCase(SimpleTestCase):
                 Scenario(
                     [PRISONS[0]],
                     {
-                        'prison_selector': 'all',
+                        'prison_selector': MyPrisonSelectorSearchForm.PRISON_SELECTOR_ALL_PRISONS_CHOICE_VALUE,
                         'prison': [PRISONS[1]['nomis_id']],
                     },
                     {
                         'page': 1,
-                        'prison_selector': 'all',
+                        'prison_selector': MyPrisonSelectorSearchForm.PRISON_SELECTOR_ALL_PRISONS_CHOICE_VALUE,
                         'prison': [],  # reset
                     },
                     {},  # expected api query params empty because we don't want to filter by any prison
                     {
-                        'prison_selector': ['all'],
+                        'prison_selector': [MyPrisonSelectorSearchForm.PRISON_SELECTOR_ALL_PRISONS_CHOICE_VALUE],
                     },
                 ),
 

--- a/mtp_noms_ops/apps/security/tests/test_forms.py
+++ b/mtp_noms_ops/apps/security/tests/test_forms.py
@@ -30,7 +30,7 @@ from security.tests import api_url
 
 ValidationScenario = namedtuple('ValidationScenario', 'data expected_errors')
 
-PRISONS = [
+SAMPLE_PRISONS = [
     {
         'nomis_id': 'IXB', 'general_ledger_code': '10200042',
         'name': 'HMP Prison 1', 'short_name': 'Prison 1',
@@ -54,25 +54,13 @@ PRISONS = [
 ]
 
 
-class MyAmountSearchForm(AmountSearchFormMixin, SecurityForm):
-    """
-    SecurityForm used to test AmountSearchFormMixin.
-    """
-
-
-class MyPrisonSelectorSearchForm(PrisonSelectorSearchFormMixin, SecurityForm):
-    """
-    SecurityForm used to test PrisonSelectorSearchFormMixin.
-    """
-
-
 def mock_prison_response(rsps):
     rsps.add(
         rsps.GET,
         api_url('/prisons/'),
         json={
-            'count': 2,
-            'results': PRISONS,
+            'count': len(SAMPLE_PRISONS),
+            'results': SAMPLE_PRISONS,
         }
     )
 
@@ -86,6 +74,18 @@ def mock_empty_response(rsps, path):
             'results': [],
         }
     )
+
+
+class MyAmountSearchForm(AmountSearchFormMixin, SecurityForm):
+    """
+    SecurityForm used to test AmountSearchFormMixin.
+    """
+
+
+class MyPrisonSelectorSearchForm(PrisonSelectorSearchFormMixin, SecurityForm):
+    """
+    SecurityForm used to test PrisonSelectorSearchFormMixin.
+    """
 
 
 class AmountSearchFormMixinTestCase(SimpleTestCase):
@@ -354,10 +354,10 @@ class PrisonSelectorSearchFormMixinTestCase(SimpleTestCase):
             scenarios = [
                 # selection == user's prisons AND current user's prisons == one prison
                 Scenario(
-                    [PRISONS[0]],
+                    [SAMPLE_PRISONS[0]],
                     {
                         'prison_selector': YOUR_PRISONS_QUERY_STRING_VALUE,
-                        'prison': [PRISONS[1]['nomis_id']],
+                        'prison': [SAMPLE_PRISONS[1]['nomis_id']],
                     },
                     {
                         'page': 1,
@@ -365,7 +365,7 @@ class PrisonSelectorSearchFormMixinTestCase(SimpleTestCase):
                         'prison': [],  # reset
                     },
                     {
-                        'prison': [PRISONS[0]['nomis_id']],
+                        'prison': [SAMPLE_PRISONS[0]['nomis_id']],
                     },
                     {
                         'prison_selector': [YOUR_PRISONS_QUERY_STRING_VALUE],
@@ -377,7 +377,7 @@ class PrisonSelectorSearchFormMixinTestCase(SimpleTestCase):
                     [],
                     {
                         'prison_selector': YOUR_PRISONS_QUERY_STRING_VALUE,
-                        'prison': [PRISONS[1]['nomis_id']],
+                        'prison': [SAMPLE_PRISONS[1]['nomis_id']],
                     },
                     {
                         'page': 1,
@@ -392,10 +392,10 @@ class PrisonSelectorSearchFormMixinTestCase(SimpleTestCase):
 
                 # selection == all
                 Scenario(
-                    [PRISONS[0]],
+                    [SAMPLE_PRISONS[0]],
                     {
                         'prison_selector': MyPrisonSelectorSearchForm.PRISON_SELECTOR_ALL_PRISONS_CHOICE_VALUE,
-                        'prison': [PRISONS[1]['nomis_id']],
+                        'prison': [SAMPLE_PRISONS[1]['nomis_id']],
                     },
                     {
                         'page': 1,
@@ -410,22 +410,22 @@ class PrisonSelectorSearchFormMixinTestCase(SimpleTestCase):
 
                 # selection == exact
                 Scenario(
-                    [PRISONS[0]],
+                    [SAMPLE_PRISONS[0]],
                     {
                         'prison_selector': PrisonSelectorSearchFormMixin.PRISON_SELECTOR_EXACT_PRISON_CHOICE_VALUE,
-                        'prison': [PRISONS[1]['nomis_id']],
+                        'prison': [SAMPLE_PRISONS[1]['nomis_id']],
                     },
                     {
                         'page': 1,
                         'prison_selector': PrisonSelectorSearchFormMixin.PRISON_SELECTOR_EXACT_PRISON_CHOICE_VALUE,
-                        'prison': [PRISONS[1]['nomis_id']],
+                        'prison': [SAMPLE_PRISONS[1]['nomis_id']],
                     },
                     {
-                        'prison': [PRISONS[1]['nomis_id']],
+                        'prison': [SAMPLE_PRISONS[1]['nomis_id']],
                     },
                     {
                         'prison_selector': [PrisonSelectorSearchFormMixin.PRISON_SELECTOR_EXACT_PRISON_CHOICE_VALUE],
-                        'prison': [PRISONS[1]['nomis_id']],
+                        'prison': [SAMPLE_PRISONS[1]['nomis_id']],
                     },
                 ),
 
@@ -493,7 +493,7 @@ class SecurityFormTestCase(SimpleTestCase):
 
     def setUp(self):
         super().setUp()
-        self.user_prisons = PRISONS[:1]
+        self.user_prisons = SAMPLE_PRISONS[:1]
         self.request = mock.MagicMock(
             user=mock.MagicMock(
                 token=generate_tokens(),

--- a/mtp_noms_ops/apps/security/tests/test_views.py
+++ b/mtp_noms_ops/apps/security/tests/test_views.py
@@ -22,7 +22,7 @@ from security import (
     required_permissions, hmpps_employee_flag, not_hmpps_employee_flag,
     confirmed_prisons_flag, notifications_pilot_flag, SEARCH_V2_FLAG,
 )
-from security.forms.object_list import PrisonSelectorSearchFormMixin, YOUR_PRISONS_QUERY_STRING_VALUE
+from security.forms.object_list import PrisonSelectorSearchFormMixin, PRISON_SELECTOR_USER_PRISONS_CHOICE_VALUE
 from security.models import EmailNotifications
 from security.tests import api_url, nomis_url, TEST_IMAGE_DATA
 from security.views.object_base import SEARCH_FORM_SUBMITTED_INPUT_NAME
@@ -618,7 +618,7 @@ class SearchV2SecurityTestCaseMixin:
 
         self.assertContains(
             response,
-            f'<input type="hidden" name="prison_selector" value="{YOUR_PRISONS_QUERY_STRING_VALUE}"',
+            f'<input type="hidden" name="prison_selector" value="{PRISON_SELECTOR_USER_PRISONS_CHOICE_VALUE}"',
         )
 
     def test_advanced_search_with_my_prisons_selection(self):
@@ -634,7 +634,8 @@ class SearchV2SecurityTestCaseMixin:
             mock_prison_response(rsps=rsps)
 
             response = self.client.get(
-                f'{reverse(self.advanced_search_view_name)}?prison_selector={YOUR_PRISONS_QUERY_STRING_VALUE}',
+                f'{reverse(self.advanced_search_view_name)}'
+                f'?prison_selector={PRISON_SELECTOR_USER_PRISONS_CHOICE_VALUE}',
             )
             self.assertEqual(response.status_code, 200)
 
@@ -706,7 +707,7 @@ class SearchV2SecurityTestCaseMixin:
                 },
             )
             query_string = (
-                f'ordering={self.search_ordering}&prison_selector={YOUR_PRISONS_QUERY_STRING_VALUE}'
+                f'ordering={self.search_ordering}&prison_selector={PRISON_SELECTOR_USER_PRISONS_CHOICE_VALUE}'
                 f'&advanced=False&simple_search=test'
             )
             request_url = f'{reverse(self.view_name)}?{query_string}&{SEARCH_FORM_SUBMITTED_INPUT_NAME}=1'
@@ -735,7 +736,7 @@ class SearchV2SecurityTestCaseMixin:
                 },
             )
             query_string = (
-                f'ordering={self.search_ordering}&prison_selector={YOUR_PRISONS_QUERY_STRING_VALUE}'
+                f'ordering={self.search_ordering}&prison_selector={PRISON_SELECTOR_USER_PRISONS_CHOICE_VALUE}'
                 '&advanced=True'
             )
             request_url = (

--- a/mtp_noms_ops/apps/settings/tests/test_views.py
+++ b/mtp_noms_ops/apps/settings/tests/test_views.py
@@ -11,7 +11,9 @@ from security import (
 )
 from security.tests import api_url
 from security.tests.test_views import (
-    SecurityBaseTestCase, sample_prison_list, sample_prisons
+    mock_prison_response,
+    SAMPLE_PRISONS,
+    SecurityBaseTestCase,
 )
 
 
@@ -23,7 +25,7 @@ class ConfirmPrisonTestCase(SecurityBaseTestCase):
 
     @responses.activate
     def test_redirects_when_no_flag(self):
-        sample_prison_list()
+        mock_prison_response()
         self.login(user_data=self.get_user_data(
             flags=[hmpps_employee_flag])
         )
@@ -59,9 +61,9 @@ class ConfirmPrisonTestCase(SecurityBaseTestCase):
 
     @responses.activate
     def test_prison_confirmation(self):
-        current_prison = sample_prisons[0]
-        new_prison = sample_prisons[1]
-        sample_prison_list()
+        current_prison = SAMPLE_PRISONS[0]
+        new_prison = SAMPLE_PRISONS[1]
+        mock_prison_response()
         self.login(user_data=self.get_user_data(
             prisons=[current_prison], flags=[hmpps_employee_flag])
         )
@@ -112,8 +114,8 @@ class ConfirmPrisonTestCase(SecurityBaseTestCase):
 
     @responses.activate
     def test_prison_confirmation_all_prisons(self):
-        current_prison = sample_prisons[0]
-        sample_prison_list()
+        current_prison = SAMPLE_PRISONS[0]
+        mock_prison_response()
         self.login(user_data=self.get_user_data(
             prisons=[current_prison], flags=[hmpps_employee_flag])
         )
@@ -196,9 +198,9 @@ class ChangePrisonTestCase(SecurityBaseTestCase):
         Test changing my prisons' data by replacing an existing previously selected
         prison with a new one.
         """
-        current_prison = sample_prisons[0]
-        new_prison = sample_prisons[1]
-        sample_prison_list()
+        current_prison = SAMPLE_PRISONS[0]
+        new_prison = SAMPLE_PRISONS[1]
+        mock_prison_response()
         self.login(user_data=self.get_user_data(
             prisons=[current_prison], flags=[
                 hmpps_employee_flag,
@@ -224,9 +226,9 @@ class ChangePrisonTestCase(SecurityBaseTestCase):
         with a new textfield for the new prison added.
         Note: the test does not save the form but it only tests its initialisation.
         """
-        current_prison = sample_prisons[0]
-        new_prison = sample_prisons[1]
-        sample_prison_list()
+        current_prison = SAMPLE_PRISONS[0]
+        new_prison = SAMPLE_PRISONS[1]
+        mock_prison_response()
         self.login(user_data=self.get_user_data(
             prisons=[current_prison], flags=[
                 hmpps_employee_flag,
@@ -247,9 +249,9 @@ class ChangePrisonTestCase(SecurityBaseTestCase):
         Test that clicking on 'Remove' redirects to the same page with that textfield removed.
         Note: the test does not save the form but it only tests its initialisation.
         """
-        current_prison = sample_prisons[0]
-        new_prison = sample_prisons[1]
-        sample_prison_list()
+        current_prison = SAMPLE_PRISONS[0]
+        new_prison = SAMPLE_PRISONS[1]
+        mock_prison_response()
         self.login(user_data=self.get_user_data(
             prisons=[current_prison], flags=[
                 hmpps_employee_flag,
@@ -271,9 +273,9 @@ class ChangePrisonTestCase(SecurityBaseTestCase):
         Test that clicking on 'Add all prisons' redirects to the 'All Prisons' version of the page.
         Note: the test does not save the form but it only tests its initialisation.
         """
-        current_prison = sample_prisons[0]
-        new_prison = sample_prisons[1]
-        sample_prison_list()
+        current_prison = SAMPLE_PRISONS[0]
+        new_prison = SAMPLE_PRISONS[1]
+        mock_prison_response()
         self.login(user_data=self.get_user_data(
             prisons=[current_prison], flags=[
                 hmpps_employee_flag,
@@ -295,8 +297,8 @@ class ChangePrisonTestCase(SecurityBaseTestCase):
         (not the 'All Prison' one).
         Note: the test does not save the form but it only tests its initialisation.
         """
-        current_prison = sample_prisons[0]
-        sample_prison_list()
+        current_prison = SAMPLE_PRISONS[0]
+        mock_prison_response()
         self.login(user_data=self.get_user_data(
             prisons=[current_prison], flags=[
                 hmpps_employee_flag,
@@ -316,10 +318,10 @@ class ChangePrisonTestCase(SecurityBaseTestCase):
         """
         Test that if the next param is passed in, the view redirects to it after saving the changes.
         """
-        current_prison = sample_prisons[0]
-        new_prison = sample_prisons[1]
+        current_prison = SAMPLE_PRISONS[0]
+        new_prison = SAMPLE_PRISONS[1]
 
-        sample_prison_list()
+        mock_prison_response()
         self.login(
             user_data=self.get_user_data(
                 prisons=[current_prison],
@@ -344,10 +346,10 @@ class ChangePrisonTestCase(SecurityBaseTestCase):
         Test that if the passed in next param is not in the allowed hosts list,
         the view redirects to the default view after saving the changes instead.
         """
-        current_prison = sample_prisons[0]
-        new_prison = sample_prisons[1]
+        current_prison = SAMPLE_PRISONS[0]
+        new_prison = SAMPLE_PRISONS[1]
 
-        sample_prison_list()
+        mock_prison_response()
         self.login(
             user_data=self.get_user_data(
                 prisons=[current_prison],

--- a/mtp_noms_ops/assets-src/javascripts/modules/security-forms.js
+++ b/mtp_noms_ops/assets-src/javascripts/modules/security-forms.js
@@ -2,8 +2,12 @@
 /* globals prisonData */
 'use strict';
 
-exports.SecurityForms = {
+var LegacySecurityForms = {
   init: function () {
+    if (!$('.mtp-security-form').length) {
+      return;
+    }
+
     this.bindAmountPatternSelection();
     this.bindPaymentSourceSelection();
     this.bindPrisonSelection();
@@ -133,6 +137,79 @@ exports.SecurityForms = {
     $regionSelect.change(update);
     $categorySelect.change(update);
     $populationSelect.change(update);
+    update();
+  }
+};
+
+exports.SecurityForms = {
+  init: function () {
+    LegacySecurityForms.init();
+
+    if (!$('.mtp-security-advanced-search').length) {
+      return;
+    }
+    this.bindAmountPatternSelection();
+    this.bindPrisonSelection();
+  },
+
+  hideFieldWrapper: function (wrapper) {
+    wrapper.removeClass('form-group-error').hide();
+    wrapper.find('input').val('').removeClass('form-control-error');
+    wrapper.find('.error-message').remove();
+  },
+
+  bindAmountPatternSelection: function () {
+    var $patternSelect = $('[name=amount_pattern]');
+    var self = this;
+
+    if (!$patternSelect.length) {
+      return;
+    }
+
+    var $exactWrapper = $('#id_amount_exact-wrapper');
+    var $penceWrapper = $('#id_amount_pence-wrapper');
+
+    function update () {
+      switch ($patternSelect.filter(':checked').val()) {
+        case 'exact':
+          $exactWrapper.show();
+          self.hideFieldWrapper($penceWrapper);
+          break;
+        case 'pence':
+          self.hideFieldWrapper($exactWrapper);
+          $penceWrapper.show();
+          break;
+        default:
+          self.hideFieldWrapper($exactWrapper);
+          self.hideFieldWrapper($penceWrapper);
+      }
+    }
+
+    $patternSelect.change(update);
+    update();
+  },
+
+  bindPrisonSelection: function () {
+    var $prisonSelector = $('[name=prison_selector]');
+    var self = this;
+
+    if (!$prisonSelector.length) {
+      return;
+    }
+
+    var $prisonWrapper = $('#id_prison-wrapper');
+
+    function update () {
+      switch ($prisonSelector.filter(':checked').val()) {
+        case 'exact':
+          $prisonWrapper.show();
+          break;
+        default:
+          self.hideFieldWrapper($prisonWrapper);
+      }
+    }
+
+    $prisonSelector.change(update);
     update();
   }
 };

--- a/mtp_noms_ops/assets-src/stylesheets/views/_security-form-fields.scss
+++ b/mtp_noms_ops/assets-src/stylesheets/views/_security-form-fields.scss
@@ -183,10 +183,15 @@ select[disabled] {
   }
 
   #id_amount_exact-wrapper,
-  #id_amount_pence-wrapper {
+  #id_amount_pence-wrapper,
+  #id_prison-wrapper {
     @extend .panel;
     border-left-width: 5px;
     margin-left: 18px;
-    padding-left: 26px;
+    padding: 0 0 0 26px;
+  }
+
+  .mtp-invoice-nr-header {
+    margin-top: 15px;
   }
 }

--- a/mtp_noms_ops/templates/security/base_advanced_search.html
+++ b/mtp_noms_ops/templates/security/base_advanced_search.html
@@ -14,10 +14,11 @@
 {% block body_classes %}{{ block.super }} mtp-with-spaced-header{% endblock body_classes %}
 
 {% block inner_content %}
-  <form class="mtp-security-advanced-search js-FormAnalytics" method="get">
+  <form class="mtp-security-advanced-search mtp-autocomplete js-FormAnalytics" method="get">
     <input type="hidden" name="{{ form.advanced.html_name }}" value="True" />
     <input type="hidden" name="{{ search_form_submitted_input_name }}" value="1" />
-    {{ form.prison_selector.as_hidden }}
+
+    {% include 'mtp_common/forms/error-summary.html' with form=form only %}
 
     <div class="grid-row">
       <div class="column-two-thirds">

--- a/mtp_noms_ops/templates/security/base_advanced_search.html
+++ b/mtp_noms_ops/templates/security/base_advanced_search.html
@@ -17,9 +17,7 @@
   <form class="mtp-security-advanced-search js-FormAnalytics" method="get">
     <input type="hidden" name="{{ form.advanced.html_name }}" value="True" />
     <input type="hidden" name="{{ search_form_submitted_input_name }}" value="1" />
-  {% for prison in request.user_prisons %}
-    <input type="hidden" name="prison" value="{{ prison.nomis_id }}" />
-  {% endfor %}
+    {{ form.prison_selector.as_hidden }}
 
     <div class="grid-row">
       <div class="column-two-thirds">

--- a/mtp_noms_ops/templates/security/credits_advanced_search.html
+++ b/mtp_noms_ops/templates/security/credits_advanced_search.html
@@ -61,4 +61,5 @@
   {% include 'mtp_common/forms/field.html' with field=form.prisoner_number %}
   {% include 'mtp_common/forms/field.html' with field=form.prisoner_name %}
 
+  {% include 'security/forms/prison-selector-fieldset.html' %}
 {% endblock advanced_search_fields %}

--- a/mtp_noms_ops/templates/security/disbursements_advanced_search.html
+++ b/mtp_noms_ops/templates/security/disbursements_advanced_search.html
@@ -55,7 +55,9 @@
   {% include 'mtp_common/forms/field.html' with field=form.prisoner_number %}
   {% include 'mtp_common/forms/field.html' with field=form.prisoner_name %}
 
-  <div class="heading-large">{% trans 'Invoice number' %}</div>
+  {% include 'security/forms/prison-selector-fieldset.html' %}
+
+  <div class="heading-large mtp-invoice-nr-header">{% trans 'Invoice number' %}</div>
   {% include 'mtp_common/forms/field.html' with field=form.invoice_number %}
 
 {% endblock advanced_search_fields %}

--- a/mtp_noms_ops/templates/security/forms/prison-selector-fieldset.html
+++ b/mtp_noms_ops/templates/security/forms/prison-selector-fieldset.html
@@ -16,7 +16,7 @@
           <input id="{{ field.html_name }}-{{ value }}" type="radio" name="{{ field.html_name }}" value="{{ value }}" {% if value == field.value %}checked{% endif %}>
 
           <label for="{{ field.html_name }}-{{ value }}">
-            {% if value == YOUR_PRISONS_QUERY_STRING_VALUE %}
+            {% if value == PRISON_SELECTOR_USER_PRISONS_CHOICE_VALUE %}
               {% include 'security/forms/user-prison-names-ellipsis.html' %}
             {% else %}
               {{ label }}

--- a/mtp_noms_ops/templates/security/forms/prison-selector-fieldset.html
+++ b/mtp_noms_ops/templates/security/forms/prison-selector-fieldset.html
@@ -1,0 +1,47 @@
+{% load i18n %}
+
+<div class="heading-large">{% trans 'Prison' %}</div>
+{% with field=form.prison_selector choices=form.prison_selector.field.choices %}
+  <fieldset class="form-group">
+    <legend id="{{ field.id_for_label }}-label" class="visually-hidden">
+      <strong>{{ field.label }}</strong>
+    </legend>
+
+    <div class="{% if field.errors %}form-group-error{% endif %}">
+      {% for value, label in choices %}
+        {% if not user.user_data.prisons and value == form.PRISON_SELECTOR_ALL_PRISONS_CHOICE_VALUE %}
+          {% comment %}User's prisons is already all prisons so we don't want to have two repeated choices.{% endcomment %}
+        {% else %}
+        <div class="multiple-choice">
+          <input id="{{ field.html_name }}-{{ value }}" type="radio" name="{{ field.html_name }}" value="{{ value }}" {% if value == field.value %}checked{% endif %}>
+
+          <label for="{{ field.html_name }}-{{ value }}">
+            {% if value == YOUR_PRISONS_QUERY_STRING_VALUE %}
+              {% include 'security/forms/user-prison-names-ellipsis.html' %}
+            {% else %}
+              {{ label }}
+            {% endif %}
+          </label>
+
+        </div>
+        {% endif %}
+      {% endfor %}
+
+      {% with sub_field=form.prison %}
+      <div id="{{ sub_field.id_for_label }}-wrapper" class="form-group {% if sub_field.errors %}form-group-error{% endif %}">
+
+        {% include 'mtp_common/forms/field-label.html' with field=sub_field only %}
+        {% include 'mtp_common/forms/field-errors.html' with field=sub_field only %}
+
+        <select id="{{ sub_field.id_for_label }}" class="form-control {% if sub_field.errors %}form-control-error{% endif %} mtp-autocomplete" name="{{ sub_field.html_name }}">
+            <option value=""></option>
+          {% for key, title in sub_field.field.choices %}
+            <option value="{{ key }}" {% if key in sub_field.value %}selected{% endif %}>{{ title }}</option>
+          {% endfor %}
+        </select>
+
+      </div>
+      {% endwith %}
+    </div>
+  </fieldset>
+{% endwith %}

--- a/mtp_noms_ops/templates/security/forms/prison-switcher.html
+++ b/mtp_noms_ops/templates/security/forms/prison-switcher.html
@@ -1,21 +1,9 @@
-{% load i18n security %}
+{% load i18n %}
 
 {% if request.can_see_search_v2 %}
   <div class="mtp-prison-switcher print-hidden">
     <div class="mtp-prison-switcher__prison-names">
-      {% if not user.user_data.prisons %}
-        {% trans 'All prisons' %}
-      {% else %}
-        {% get_split_prison_names user.user_data.prisons 4 as split_prison_names %}
-
-        {{ split_prison_names.prison_names }}
-
-        {% if split_prison_names.total_remaining %}
-          {% blocktrans trimmed with total_remaining=split_prison_names.total_remaining %}
-            and {{ total_remaining }} more
-          {% endblocktrans %}
-        {% endif %}
-      {% endif %}
+      {% include 'security/forms/user-prison-names-ellipsis.html' %}
     </div>
 
     <div class="mtp-prison-switcher__change-link">

--- a/mtp_noms_ops/templates/security/forms/top-area-object-list.html
+++ b/mtp_noms_ops/templates/security/forms/top-area-object-list.html
@@ -33,10 +33,7 @@
     <div class="mtp-security-form--simple">
     <input type="hidden" name="{{ search_form_submitted_input_name }}" value="1" />
     {{ form.ordering.as_hidden }}
-
-    {% for prison in request.user_prisons %}
-        <input type="hidden" name="prison" value="{{ prison.nomis_id }}" />
-    {% endfor %}
+    {{ form.prison_selector.as_hidden }}
 
     {% with field=form.simple_search %}
       <div id="{{ field.id_for_label }}-wrapper" class="form-group {% if field.errors %}form-group-error{% endif %}">

--- a/mtp_noms_ops/templates/security/forms/user-prison-names-ellipsis.html
+++ b/mtp_noms_ops/templates/security/forms/user-prison-names-ellipsis.html
@@ -1,0 +1,15 @@
+{% load i18n security %}
+
+{% if not user.user_data.prisons %}
+  {% trans 'All prisons' %}
+{% else %}
+  {% get_split_prison_names user.user_data.prisons 4 as split_prison_names %}
+
+  {{ split_prison_names.prison_names }}
+
+  {% if split_prison_names.total_remaining %}
+    {% blocktrans trimmed with total_remaining=split_prison_names.total_remaining %}
+      and {{ total_remaining }} more
+    {% endblocktrans %}
+  {% endif %}
+{% endif %}

--- a/mtp_noms_ops/templates/security/prisoners_advanced_search.html
+++ b/mtp_noms_ops/templates/security/prisoners_advanced_search.html
@@ -3,4 +3,6 @@
 {% block advanced_search_fields %}
   {% include 'mtp_common/forms/field.html' with field=form.prisoner_number %}
   {% include 'mtp_common/forms/field.html' with field=form.prisoner_name %}
+
+  {% include 'security/forms/prison-selector-fieldset.html' %}
 {% endblock advanced_search_fields %}

--- a/mtp_noms_ops/templates/security/senders_advanced_search.html
+++ b/mtp_noms_ops/templates/security/senders_advanced_search.html
@@ -17,4 +17,6 @@
   <div class="heading-medium">{% trans 'Bank transfer' %}</div>
   {% include 'mtp_common/forms/field.html' with field=form.sender_account_number %}
   {% include 'mtp_common/forms/field.html' with field=form.sender_sort_code %}
+
+  {% include 'security/forms/prison-selector-fieldset.html' %}
 {% endblock advanced_search_fields %}


### PR DESCRIPTION
This:
- adds a `prison_selector` field along with the existing `prison` field. Valid options for prison selector are: `All prisons`, `"My prisons"`, or `A specific prison`. When the last option is specified the prison field is required.
- some constants and functions in tests were renamed to keep things consistent
- the existing hide/reveal javascript was renamed to Legacy so that it'll be easier to find and remove when v2 goes live

I would suggest reviewing the commits individually.

Not in this PR and still to be implemented:
- removal of prison switcher in advanced search form and search results page
- extra `prison` column in search results table when using advanced search

![Screenshot 2019-08-19 at 14 47 44](https://user-images.githubusercontent.com/178865/63271225-95c0d580-c291-11e9-9cef-b7b4ae895288.png)
