### PR TITLE
Advanced search refinement

### DIFF
--- a/mtp_noms_ops/apps/security/forms/object_list.py
+++ b/mtp_noms_ops/apps/security/forms/object_list.py
@@ -561,6 +561,18 @@ class PrisonersFormV2(SearchFormV2Mixin, PrisonSelectorSearchFormMixin, BasePris
 
         return prisoner_number.upper()
 
+    def get_query_data(self, allow_parameter_manipulation=True):
+        """
+        Make sure the API call filters by `current_prison` instead of the `prison` field which queries
+        all historic prisons.
+        """
+        query_data = super().get_query_data(allow_parameter_manipulation=allow_parameter_manipulation)
+        if allow_parameter_manipulation:
+            prisons = query_data.pop('prison', None)
+            if prisons:
+                query_data['current_prison'] = prisons
+        return query_data
+
 
 class BaseCreditsForm(SecurityForm):
     """

--- a/mtp_noms_ops/apps/security/tests/test_forms.py
+++ b/mtp_noms_ops/apps/security/tests/test_forms.py
@@ -997,7 +997,7 @@ class PrisonerFormV2TestCase(SecurityFormTestCase):
                     'offset': ['0'],
                     'limit': ['20'],
                     'ordering': ['-sender_count'],
-                    'prison': [  # PRISON_SELECTOR_USER_PRISONS_CHOICE_VALUE expands into user prisons
+                    'current_prison': [  # PRISON_SELECTOR_USER_PRISONS_CHOICE_VALUE expands into user prisons
                         prison['nomis_id']
                         for prison in self.user_prisons
                     ],
@@ -1054,7 +1054,7 @@ class PrisonerFormV2TestCase(SecurityFormTestCase):
                     'limit': ['20'],
                     'ordering': ['-credit_total'],
                     'simple_search': ['Joh'],
-                    'prison': [  # PRISON_SELECTOR_USER_PRISONS_CHOICE_VALUE expands into user prisons
+                    'current_prison': [  # PRISON_SELECTOR_USER_PRISONS_CHOICE_VALUE expands into user prisons
                         prison['nomis_id']
                         for prison in self.user_prisons
                     ],
@@ -1114,7 +1114,7 @@ class PrisonerFormV2TestCase(SecurityFormTestCase):
                     'offset': ['20'],
                     'limit': ['20'],
                     'ordering': ['-credit_total'],
-                    'prison': [  # PRISON_SELECTOR_USER_PRISONS_CHOICE_VALUE expands into user prisons
+                    'current_prison': [  # PRISON_SELECTOR_USER_PRISONS_CHOICE_VALUE expands into user prisons
                         prison['nomis_id']
                         for prison in self.user_prisons
                     ],

--- a/mtp_noms_ops/apps/security/tests/test_views.py
+++ b/mtp_noms_ops/apps/security/tests/test_views.py
@@ -44,7 +44,8 @@ SAMPLE_PRISONS = [
     {
         'nomis_id': 'AAI',
         'general_ledger_code': '001',
-        'name': 'HMP & YOI Test 1', 'short_name': 'Test 1',
+        'name': 'HMP & YOI Test 1',
+        'short_name': 'Test 1',
         'region': 'London',
         'categories': [{'description': 'Category D', 'name': 'D'},
                        {'description': 'Young Offender Institution', 'name': 'YOI'}],
@@ -56,7 +57,8 @@ SAMPLE_PRISONS = [
     {
         'nomis_id': 'BBI',
         'general_ledger_code': '002',
-        'name': 'HMP Test 2', 'short_name': 'Test 2',
+        'name': 'HMP Test 2',
+        'short_name': 'Test 2',
         'region': 'London',
         'categories': [{'description': 'Category D', 'name': 'D'}],
         'populations': [{'description': 'Male', 'name': 'male'}],
@@ -428,6 +430,16 @@ class SecurityViewTestCase(SecurityBaseTestCase):
         'credit_total': 41000,
         'prisoner_count': 3,
         'prison_count': 2,
+        'prisons': [
+            {
+                'nomis_id': 'PRN',
+                'name': 'Prison PRN',
+            },
+            {
+                'nomis_id': 'ABC',
+                'name': 'Prison ABC',
+            },
+        ],
         'bank_transfer_details': [
             {
                 'sender_name': 'MAISIE NOLAN',
@@ -445,6 +457,16 @@ class SecurityViewTestCase(SecurityBaseTestCase):
         'credit_total': 42000,
         'prisoner_count': 3,
         'prison_count': 2,
+        'prisons': [
+            {
+                'nomis_id': 'PRN',
+                'name': 'Prison PRN',
+            },
+            {
+                'nomis_id': 'ABC',
+                'name': 'Prison ABC',
+            },
+        ],
         'bank_transfer_details': [],
         'debit_card_details': [
             {
@@ -1196,11 +1218,19 @@ class SenderViewsV2TestCase(
         ]
 
     def _test_search_results_content(self, response, advanced=False):
-        self.assertContains(response, '2 payment sources')
-        self.assertContains(response, 'MAISIE NOLAN')
         response_content = response.content.decode(response.charset)
+
+        self.assertIn('2 payment sources', response_content)
+        self.assertIn('MAISIE NOLAN', response_content)
         self.assertIn('£410.00', response_content)
         self.assertIn('£420.00', response_content)
+
+        if advanced:
+            self.assertIn('Prison PRN', response_content)
+            self.assertIn('Prison ABC', response_content)
+        else:
+            self.assertNotIn('Prison PRN', response_content)
+            self.assertNotIn('Prison ABC', response_content)
 
     def test_detail_view_displays_bank_transfer_detail(self):
         sender_id = 9

--- a/mtp_noms_ops/apps/security/tests/test_views.py
+++ b/mtp_noms_ops/apps/security/tests/test_views.py
@@ -585,6 +585,9 @@ class SearchV2SecurityTestCaseMixin:
     search_results_view_name = None
     advanced_search_view_name = None
 
+    # the filter name used for API calls, it's usually prison but can sometimes be current_prison
+    prison_api_filter_name = 'prison'
+
     def get_user_data(
         self,
         *args,
@@ -688,7 +691,7 @@ class SearchV2SecurityTestCaseMixin:
             api_call_made = rsps.calls[-1].request.url
             parsed_qs = parse_qs(api_call_made.split('?', 1)[1])
             self.assertCountEqual(
-                parsed_qs['prison'],
+                parsed_qs[self.prison_api_filter_name],
                 [prison['nomis_id'] for prison in user_prisons],
             )
 
@@ -708,7 +711,7 @@ class SearchV2SecurityTestCaseMixin:
 
             api_call_made = rsps.calls[-1].request.url
             parsed_qs = parse_qs(api_call_made.split('?', 1)[1])
-            self.assertTrue('prison' not in parsed_qs)
+            self.assertTrue(self.prison_api_filter_name not in parsed_qs)
 
     def test_advanced_search_with_exact_prison_selected(self):
         """
@@ -731,7 +734,7 @@ class SearchV2SecurityTestCaseMixin:
             api_call_made = rsps.calls[-1].request.url
             parsed_qs = parse_qs(api_call_made.split('?', 1)[1])
             self.assertCountEqual(
-                parsed_qs['prison'],
+                parsed_qs[self.prison_api_filter_name],
                 [expected_prison_id],
             )
 
@@ -1465,6 +1468,7 @@ class PrisonerViewsV2TestCase(
     detail_view_name = 'security:prisoner_detail'
     search_ordering = '-sender_count'
     api_list_path = '/prisoners/'
+    prison_api_filter_name = 'current_prison'
 
     export_view_name = 'security:prisoners_export'
     export_email_view_name = 'security:prisoners_email_export'

--- a/mtp_noms_ops/apps/security/tests/test_views.py
+++ b/mtp_noms_ops/apps/security/tests/test_views.py
@@ -491,8 +491,8 @@ class SecurityViewTestCase(SecurityBaseTestCase):
         'prisoner_name': 'JAMES HALLS',
         'prisoner_number': 'A1409AE',
         'prisoner_dob': '1986-12-09',
-        'current_prison': {'nomis_id': 'PRN', 'name': 'Prison'},
-        'prisons': [{'nomis_id': 'PRN', 'name': 'Prison'}],
+        'current_prison': {'nomis_id': 'PRN', 'name': 'Prison PRN'},
+        'prisons': [{'nomis_id': 'PRN', 'name': 'Prison PRN'}],
         'provided_names': ['Jim Halls', 'JAMES HALLS', 'James Halls '],
         'created': '2016-05-25T20:24:00Z',
         'modified': '2016-05-25T20:24:00Z',
@@ -1494,8 +1494,8 @@ class PrisonerViewsV2TestCase(
             3,
             '£310.00',
             2,
-            'Prison',
-            'Prison',
+            'Prison PRN',
+            'Prison PRN',
             'Jim Halls, JAMES HALLS',
             2,
             '£290.00',
@@ -1511,6 +1511,11 @@ class PrisonerViewsV2TestCase(
         self.assertIn('JAMES HALLS', response_content)
         self.assertIn('A1409AE', response_content)
         self.assertIn('310.00', response_content)
+
+        if advanced:
+            self.assertIn('Prison PRN', response_content)
+        else:
+            self.assertNotIn('Prison PRN', response_content)
 
     @override_nomis_settings
     def test_detail_view(self):

--- a/mtp_noms_ops/templates/security/base_advanced_search.html
+++ b/mtp_noms_ops/templates/security/base_advanced_search.html
@@ -5,11 +5,6 @@
 
 {% block page_title %}{{ view.title }} – {{ block.super }}{% endblock %}
 
-{% block phase_banner %}
-  {{ block.super }}
-  {% include "security/forms/prison-switcher.html" %}
-{% endblock %}
-
 {% comment %}TODO: Move body_classes block to base.html when search V2 goes live to make all the existing pages consistent.{% endcomment %}
 {% block body_classes %}{{ block.super }} mtp-with-spaced-header{% endblock body_classes %}
 

--- a/mtp_noms_ops/templates/security/base_search_results.html
+++ b/mtp_noms_ops/templates/security/base_search_results.html
@@ -1,0 +1,17 @@
+{% extends 'base.html' %}
+{% load i18n %}
+{% load mtp_common %}
+{% load security %}
+
+{% block page_title %}{{ view.title }} – {{ block.super }}{% endblock %}
+
+{% block phase_banner %}
+  {{ block.super }}
+
+  {% if not form.advanced.value %}
+    {% include "security/forms/prison-switcher.html" %}
+  {% endif %}
+{% endblock %}
+
+{% comment %}TODO: Move body_classes block to base.html when search V2 goes live to make all the existing pages consistent.{% endcomment %}
+{% block body_classes %}{{ block.super }} mtp-with-spaced-header{% endblock body_classes %}

--- a/mtp_noms_ops/templates/security/credits_list.html
+++ b/mtp_noms_ops/templates/security/credits_list.html
@@ -1,17 +1,7 @@
-{% extends 'base.html' %}
+{% extends 'security/base_search_results.html' %}
 {% load i18n %}
 {% load mtp_common %}
 {% load security %}
-
-{% block page_title %}{{ view.title }} – {{ block.super }}{% endblock %}
-
-{% block phase_banner %}
-  {{ block.super }}
-  {% include "security/forms/prison-switcher.html" %}
-{% endblock %}
-
-{% comment %}TODO: Move body_classes block to base.html when search V2 goes live to make all the existing pages consistent.{% endcomment %}
-{% block body_classes %}{{ block.super }} mtp-with-spaced-header{% endblock body_classes %}
 
 {% block inner_content %}
   <form id="filter-credits" class="mtp-security-search js-FormAnalytics" method="get">

--- a/mtp_noms_ops/templates/security/credits_list.html
+++ b/mtp_noms_ops/templates/security/credits_list.html
@@ -33,6 +33,9 @@
               {% sortable_cell _('Date received') form.cleaned_data 'received_at' %}
               <th>{% trans 'Payment source (from)' %}</th>
               <th>{% trans 'Prisoner (to)' %}</th>
+              {% if form.advanced.value %}
+              <th>{% trans 'Prison' %}</th>
+              {% endif %}
               {% sortable_cell _('Amount') form.cleaned_data 'amount' cell_classes='numeric' %}
               <th class="numeric print-hidden">{% trans 'Action' %}</th>
             </tr>
@@ -55,6 +58,10 @@
                   <br/>
                   {% search_highlight credit.prisoner_number %}
                 </td>
+
+                {% if form.advanced.value %}
+                <td>{{ credit.prison_name }}</td>
+                {% endif %}
 
                 <td class="numeric">
                   <span class="mtp-sortable-cell--pad">

--- a/mtp_noms_ops/templates/security/disbursements_list.html
+++ b/mtp_noms_ops/templates/security/disbursements_list.html
@@ -33,6 +33,9 @@
               {% sortable_cell _('Date entered') form.cleaned_data 'created' %}
               <th>{% trans 'Prisoner (from)' %}</th>
               <th>{% trans 'Recipient (to)' %}</th>
+              {% if form.advanced.value %}
+              <th>{% trans 'Prison' %}</th>
+              {% endif %}
               {% sortable_cell _('Amount') form.cleaned_data 'amount' cell_classes='numeric' %}
               <th class="numeric print-hidden">{% trans 'Action' %}</th>
             </tr>
@@ -55,6 +58,10 @@
                   <br/>
                   {{ disbursement.recipient_email|default:_('Email not provided') }}
                 </td>
+
+                {% if form.advanced.value %}
+                <td>{{ disbursement.prison_name }}</td>
+                {% endif %}
 
                 <td class="numeric">
                   <span class="mtp-sortable-cell--pad">

--- a/mtp_noms_ops/templates/security/disbursements_list.html
+++ b/mtp_noms_ops/templates/security/disbursements_list.html
@@ -1,17 +1,7 @@
-{% extends 'base.html' %}
+{% extends 'security/base_search_results.html' %}
 {% load i18n %}
 {% load mtp_common %}
 {% load security %}
-
-{% block page_title %}{{ view.title }} – {{ block.super }}{% endblock %}
-
-{% block phase_banner %}
-  {{ block.super }}
-  {% include "security/forms/prison-switcher.html" %}
-{% endblock %}
-
-{% comment %}TODO: Move body_classes block to base.html when search V2 goes live to make all the existing pages consistent.{% endcomment %}
-{% block body_classes %}{{ block.super }} mtp-with-spaced-header{% endblock body_classes %}
 
 {% block inner_content %}
   <form id="filter-disbursements" class="mtp-security-search js-FormAnalytics" method="get">

--- a/mtp_noms_ops/templates/security/prisoners_list.html
+++ b/mtp_noms_ops/templates/security/prisoners_list.html
@@ -1,17 +1,7 @@
-{% extends 'base.html' %}
+{% extends 'security/base_search_results.html' %}
 {% load i18n %}
 {% load mtp_common %}
 {% load security %}
-
-{% block page_title %}{{ view.title }} – {{ block.super }}{% endblock %}
-
-{% block phase_banner %}
-  {{ block.super }}
-  {% include "security/forms/prison-switcher.html" %}
-{% endblock %}
-
-{% comment %}TODO: Move body_classes block to base.html when search V2 goes live to make all the existing pages consistent.{% endcomment %}
-{% block body_classes %}{{ block.super }} mtp-with-spaced-header{% endblock body_classes %}
 
 {% block inner_content %}
   <form id="filter-prisoners" class="mtp-security-search js-FormAnalytics" method="get">

--- a/mtp_noms_ops/templates/security/prisoners_list.html
+++ b/mtp_noms_ops/templates/security/prisoners_list.html
@@ -34,6 +34,9 @@
               <thead>
                 <tr>
                   <th>{% trans 'Prisoner' %}</th>
+                  {% if form.advanced.value %}
+                  <th>{% trans 'Prison' %}</th>
+                  {% endif %}
                   {% sortable_cell _('Credits received') form.cleaned_data 'credit_count' cell_classes='numeric' %}
                   {% sortable_cell _('Payment sources') form.cleaned_data 'sender_count' cell_classes='numeric' %}
                   {% sortable_cell _('Amount of credits') form.cleaned_data 'credit_total' cell_classes='numeric' %}
@@ -48,6 +51,9 @@
                       <br/>
                       {% search_highlight prisoner.prisoner_number %}
                     </td>
+                    {% if form.advanced.value %}
+                    <td>{{ prisoner.current_prison.name|default:"-" }}</td>
+                    {% endif %}
                     <td class="numeric">
                       <span class="mtp-sortable-cell--pad">
                       {{ prisoner.credit_count }}
@@ -102,6 +108,9 @@
               <thead>
                 <tr>
                   <th>{% trans 'Prisoner' %}</th>
+                  {% if form.advanced.value %}
+                  <th>{% trans 'Prison' %}</th>
+                  {% endif %}
                   {% sortable_cell _('Recipients') form.cleaned_data 'recipient_count' cell_classes='numeric' %}
                   {% sortable_cell _('Disbursements sent') form.cleaned_data 'disbursement_count' cell_classes='numeric' %}
                   {% sortable_cell _('Amount of disbursements	') form.cleaned_data 'disbursement_total' cell_classes='numeric' %}
@@ -116,6 +125,9 @@
                       <br/>
                       {% search_highlight prisoner.prisoner_number %}
                     </td>
+                    {% if form.advanced.value %}
+                    <td>{{ prisoner.current_prison.name|default:"-" }}</td>
+                    {% endif %}
                     <td class="numeric">
                       <span class="mtp-sortable-cell--pad">
                       {{ prisoner.recipient_count }}

--- a/mtp_noms_ops/templates/security/senders_list.html
+++ b/mtp_noms_ops/templates/security/senders_list.html
@@ -48,7 +48,11 @@
               <th>{% trans 'Payment method' %}</th>
               {% sortable_cell _('Number of credits sent') form.cleaned_data 'credit_count' cell_classes='numeric' %}
               {% sortable_cell _('Prisoners sent to') form.cleaned_data 'prisoner_count' cell_classes='numeric' %}
+              {% if form.advanced.value %}
+              <th>{% trans 'Prisons sent to' %}</th>
+              {% else %}
               {% sortable_cell _('Number of prisons sent to') form.cleaned_data 'prison_count' cell_classes='numeric' %}
+              {% endif %}
               {% sortable_cell _('Total amount sent') form.cleaned_data 'credit_total' cell_classes='numeric' %}
               <th class="numeric print-hidden">{% trans 'Action' %}</th>
             </tr>
@@ -114,11 +118,15 @@
                         {{ sender.prisoner_count }}
                       </span>
                     </td>
+                    {% if form.advanced.value %}
+                    <td>{{ sender.prisons|list_prison_names }}</td>
+                    {% else %}
                     <td class="numeric">
                       <span class="mtp-sortable-cell--pad">
                         {{ sender.prison_count }}
                       </span>
                     </td>
+                    {% endif %}
                     <td class="numeric">
                       <span class="mtp-sortable-cell--pad">
                         {{ sender.credit_total|currency }}

--- a/mtp_noms_ops/templates/security/senders_list.html
+++ b/mtp_noms_ops/templates/security/senders_list.html
@@ -1,17 +1,7 @@
-{% extends 'base.html' %}
+{% extends 'security/base_search_results.html' %}
 {% load i18n %}
 {% load mtp_common %}
 {% load security %}
-
-{% block page_title %}{{ view.title }} – {{ block.super }}{% endblock %}
-
-{% block phase_banner %}
-  {{ block.super }}
-  {% include "security/forms/prison-switcher.html" %}
-{% endblock %}
-
-{% comment %}TODO: Move body_classes block to base.html when search V2 goes live to make all the existing pages consistent.{% endcomment %}
-{% block body_classes %}{{ block.super }} mtp-with-spaced-header{% endblock body_classes %}
 
 {% block inner_content %}
   <form id="filter-senders" class="mtp-security-search js-FormAnalytics" method="get">


### PR DESCRIPTION
Depends on https://github.com/ministryofjustice/money-to-prisoners-api/pull/530

This:
- adds the `prison` column to the search results V2 page when using the advanced search
- removes the prison switcher when using the advanced search
- changes the prisoners search logic to use `current_prison` instead of the previous historic `prison`s.

### Credits
![Screenshot 2019-08-20 at 16 29 09](https://user-images.githubusercontent.com/178865/63361244-a93e7000-c367-11e9-93eb-c5a10f62464e.png)

### Disbursements
![Screenshot 2019-08-20 at 16 29 33](https://user-images.githubusercontent.com/178865/63361279-b6f3f580-c367-11e9-9044-ef746db940e8.png)

### Prisoners
![Screenshot 2019-08-20 at 16 27 47](https://user-images.githubusercontent.com/178865/63361126-7d22ef00-c367-11e9-879d-0df8d56a5769.png)

### Payment sources
![Screenshot 2019-08-20 at 16 28 37](https://user-images.githubusercontent.com/178865/63361192-99bf2700-c367-11e9-881a-b795ae4a01be.png)
