### PR TITLE
Search copy changes

### DIFF
--- a/mtp_noms_ops/apps/security/forms/object_list.py
+++ b/mtp_noms_ops/apps/security/forms/object_list.py
@@ -498,7 +498,7 @@ class SendersFormV2(
     sender_postcode = forms.CharField(label=_('Postcode'), required=False)
 
     # NB: ensure that these templates are HTML-safe
-    filtered_description_template = 'Results containing {filter_description}.'
+    filtered_description_template = 'Results containing {filter_description}'
     unfiltered_description_template = ''
 
     description_templates = (
@@ -670,7 +670,7 @@ class PrisonersFormV2(SearchFormV2Mixin, PrisonSelectorSearchFormMixin, BasePris
     prisoner_name = forms.CharField(label=_('Prisoner name'), required=False)
 
     # NB: ensure that these templates are HTML-safe
-    filtered_description_template = 'Results containing {filter_description}.'
+    filtered_description_template = 'Results containing {filter_description}'
     unfiltered_description_template = ''
 
     description_templates = (
@@ -928,7 +928,7 @@ class CreditsFormV2(
     exclusive_date_params = ['received_at__lt']
 
     # NB: ensure that these templates are HTML-safe
-    filtered_description_template = 'Results containing {filter_description}.'
+    filtered_description_template = 'Results containing {filter_description}'
     unfiltered_description_template = ''
 
     description_templates = (
@@ -1221,7 +1221,7 @@ class DisbursementsFormV2(
     exclusive_date_params = ['created__lt']
 
     # NB: ensure that these templates are HTML-safe
-    filtered_description_template = 'Results containing {filter_description}.'
+    filtered_description_template = 'Results containing {filter_description}'
     unfiltered_description_template = ''
 
     description_templates = (

--- a/mtp_noms_ops/apps/security/views/object_base.py
+++ b/mtp_noms_ops/apps/security/views/object_base.py
@@ -203,7 +203,7 @@ class SecurityView(FormView):
                         'name': _('Advanced search'),
                         'url': f'{reverse(self.advanced_search_view)}?{kwargs["form"].query_string}',
                     },
-                    {'name': _('Search results')},
+                    {'name': _('Advanced search results')},
                 ]
 
             return [

--- a/mtp_noms_ops/templates/security/forms/top-area-object-list.html
+++ b/mtp_noms_ops/templates/security/forms/top-area-object-list.html
@@ -3,7 +3,11 @@
   <header>
   <h1 class="heading-xlarge">
     <span class="heading-secondary">{{ view.title }}</span>
-    {% trans 'Search results' %}
+    {% if form.advanced.value %}
+      {% trans 'Advanced search results' %}
+    {% else %}
+      {% trans 'Search results' %}
+    {% endif %}
   </h1>
   </header>
 


### PR DESCRIPTION
This:
- removes the full stop in search results / search description copy
- changes breadcrumbs and page heading on the search results page to say _Advanced search results_ when using the advanced search