### PR TITLE
Search again

### DIFF
--- a/mtp_noms_ops/apps/security/views/object_base.py
+++ b/mtp_noms_ops/apps/security/views/object_base.py
@@ -208,7 +208,7 @@ class SecurityView(FormView):
 
             return [
                 {'name': _('Home'), 'url': reverse('security:dashboard')},
-                {'name': self.title, 'url': f'{reverse(self.simple_search_view)}?{kwargs["form"].query_string}'},
+                {'name': self.title, 'url': f'{reverse(self.simple_search_view)}?{prisons_param}'},
                 {'name': _('Search results')},
             ]
 

--- a/mtp_noms_ops/assets-src/stylesheets/views/_security-results.scss
+++ b/mtp_noms_ops/assets-src/stylesheets/views/_security-results.scss
@@ -155,3 +155,7 @@
     padding: 0;
   }
 }
+
+#filter-prisoners .mtp-results-list-wrapper {
+  margin-bottom: $gutter;
+}

--- a/mtp_noms_ops/templates/security/credits_list.html
+++ b/mtp_noms_ops/templates/security/credits_list.html
@@ -93,6 +93,11 @@
       </div>
     {% endif %}
 
+  {% if is_search_results %}
+    {% with search_form_item=breadcrumbs|slice:":-1"|last %}
+      <a href="{{ search_form_item.url }}" class="button">{% trans 'Search again' %}</a>
+    {% endwith%}
+  {% endif %}
   </form>
 
 {% endblock %}

--- a/mtp_noms_ops/templates/security/disbursements_list.html
+++ b/mtp_noms_ops/templates/security/disbursements_list.html
@@ -93,6 +93,11 @@
       </div>
     {% endif %}
 
+  {% if is_search_results %}
+    {% with search_form_item=breadcrumbs|slice:":-1"|last %}
+      <a href="{{ search_form_item.url }}" class="button">{% trans 'Search again' %}</a>
+    {% endwith%}
+  {% endif %}
   </form>
 
 {% endblock %}

--- a/mtp_noms_ops/templates/security/prisoners_list.html
+++ b/mtp_noms_ops/templates/security/prisoners_list.html
@@ -170,6 +170,11 @@
     </div>
     {% endif %}
 
+  {% if is_search_results %}
+    {% with search_form_item=breadcrumbs|slice:":-1"|last %}
+      <a href="{{ search_form_item.url }}" class="button">{% trans 'Search again' %}</a>
+    {% endwith%}
+  {% endif %}
   </form>
 
 {% endblock %}

--- a/mtp_noms_ops/templates/security/senders_list.html
+++ b/mtp_noms_ops/templates/security/senders_list.html
@@ -158,6 +158,11 @@
       </div>
     {% endif %}
 
+  {% if is_search_results %}
+    {% with search_form_item=breadcrumbs|slice:":-1"|last %}
+      <a href="{{ search_form_item.url }}" class="button">{% trans 'Search again' %}</a>
+    {% endwith%}
+  {% endif %}
   </form>
 
 {% endblock %}


### PR DESCRIPTION
This:

### 1. Resets the search term when going back to simple search form

Before: going back to the simple search form using the breadcrumbs would keep the search term and would filter the list.

After: the search term is reset so that it's obvious that the list below the form is not filtered

### 2. Adds the `search again` button to the search results page 

When clicked, it takes you to the simple search form or the advanced search form.

<img width="721" alt="Screenshot 2019-08-30 at 14 55 08" src="https://user-images.githubusercontent.com/178865/64026554-e8727b00-cb36-11e9-9171-929e39388e93.png">
