### PR TITLE
Count export/print as pageviews

### DIFF
--- a/mtp_noms_ops/assets-src/javascripts/modules/form-analytics.js
+++ b/mtp_noms_ops/assets-src/javascripts/modules/form-analytics.js
@@ -44,6 +44,11 @@ exports.FormAnalytics = {
       var eventDetails = $element.data('click-track').split(',');
       if (eventDetails.length === 2) {
         sendEvent('SecurityFormsExport', eventDetails[0], eventDetails[1]);
+
+        analytics.Analytics.rawSend(
+          'pageview',
+          $element.attr('href').split('?')[0]
+        );
       }
     });
   }

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,4 +1,4 @@
 # Place development dependencies here
 -r base.txt
 
-money-to-prisoners-common[testing]>=9.8,<9.9
+money-to-prisoners-common[testing]>=9.9,<9.10

--- a/requirements/docker.txt
+++ b/requirements/docker.txt
@@ -1,6 +1,6 @@
 # Place docker dependencies here
 -r base.txt
 
-money-to-prisoners-common[monitoring]>=9.8,<9.9
+money-to-prisoners-common[monitoring]>=9.9,<9.10
 
 uWSGI==2.0.17


### PR DESCRIPTION
This sends ga pageview events when a user clicks on print or export so that the related data can be analysed along with other pageviews.

It depends on https://github.com/ministryofjustice/money-to-prisoners-common/pull/357