### PR TITLE
Remove border-bottom from search highlight

### DIFF
--- a/mtp_noms_ops/assets-src/stylesheets/views/_security-results.scss
+++ b/mtp_noms_ops/assets-src/stylesheets/views/_security-results.scss
@@ -142,14 +142,12 @@
 }
 
 .mtp-search-highlight {
-  border-bottom: 3px solid #ffbf47;
   margin-right: 1px;
   background-color: #fff2d3;
   padding: 2px 0px 0px;
 
   // reset with print as IE8 doesn't support @media not print for the rule above
   @media print {
-    border-bottom: 0;
     margin-right: 0;
     background-color: transparent;
     padding: 0;


### PR DESCRIPTION
Highlighting in the search results table was not displaying properly as there was insufficient vertical space between the lines in the table.

This gets rid of the border-bottom.

**Before**

![highlight-before](https://user-images.githubusercontent.com/178865/64258047-6b704880-cf1e-11e9-9ce0-6bef41f23f55.png)


**After**

![Screenshot 2019-09-04 at 14 17 02](https://user-images.githubusercontent.com/178865/64258178-af634d80-cf1e-11e9-8799-c5695714b50e.png)
