### PR TITLE
GA refactoring

### DIFF
--- a/mtp_noms_ops/apps/security/forms/object_list.py
+++ b/mtp_noms_ops/apps/security/forms/object_list.py
@@ -38,6 +38,10 @@ class SearchFormV2Mixin(forms.Form):
     # indicates whether the form was used in advanced search
     advanced = forms.BooleanField(initial=False, required=False)
 
+    def get_ga_event_category(self):
+        """GA event category."""
+        return f'form-errors-{self.__class__.__name__}'
+
     def was_advanced_search_used(self):
         return self.cleaned_data.get('advanced', False)
 

--- a/mtp_noms_ops/assets-src/javascripts/modules/form-analytics.js
+++ b/mtp_noms_ops/assets-src/javascripts/modules/form-analytics.js
@@ -10,7 +10,7 @@ exports.FormAnalytics = {
   bindForm: function () {
     var $form = $(this);
     var formId = $form.attr('id');
-    var initialInputs = $form.serializeArray();
+    var initialInputs = $form.find(":input:not(:hidden)").serializeArray();
 
     function sendEvent (category, action, label) {
       analytics.Analytics.send(
@@ -18,9 +18,10 @@ exports.FormAnalytics = {
       );
     }
 
-    $form.on('submit', function () {
+    $form.on('submit', function (e) {
       // send event for every changed form field name
-      var inputs = $form.serializeArray();
+      var inputs = $form.find(":input:not(:hidden)").serializeArray();
+      var nonEmptyFilters = [];
       $.each(inputs, function () {
         var changed = true;
         for (var i = 0; i < initialInputs.length; i++) {
@@ -30,12 +31,23 @@ exports.FormAnalytics = {
           }
         }
         if (this.value) {
+          nonEmptyFilters.push(this.name);
+
           if (changed) {
+            // TODO: delete after search V2 goes live ?
             sendEvent('SecurityFormsFilter', formId, this.name);
           }
-          sendEvent('SecurityForms', formId, this.name);
+          sendEvent('SecurityForms', formId, this.name);  // TODO: delete after search V2 goes live.
+
+          // send one event per filter
+          sendEvent('form-submitted-single-filter', formId, this.name);
         }
       });
+
+      // send also an event for all combined filters used
+      if (nonEmptyFilters.length) {
+        sendEvent('form-submitted-combined-filters', formId, nonEmptyFilters.sort().join(','));
+      }
     });
 
     $('.js-FormAnalytics-click', $form[0]).click(function () {

--- a/mtp_noms_ops/assets-src/javascripts/modules/form-analytics.js
+++ b/mtp_noms_ops/assets-src/javascripts/modules/form-analytics.js
@@ -55,6 +55,9 @@ exports.FormAnalytics = {
       var $element = $(this);
       var eventDetails = $element.data('click-track').split(',');
       if (eventDetails.length === 2) {
+        sendEvent('form-link', eventDetails[0], eventDetails[1]);
+
+        // TODO: delete after search V2 goes live.
         sendEvent('SecurityFormsExport', eventDetails[0], eventDetails[1]);
 
         analytics.Analytics.rawSend(

--- a/mtp_noms_ops/assets-src/stylesheets/views/_security-form-fields.scss
+++ b/mtp_noms_ops/assets-src/stylesheets/views/_security-form-fields.scss
@@ -94,7 +94,7 @@ select[disabled] {
   }
 }
 
-#filter-senders {
+#simple-search-payment-sources {
   .column-one-third {
     .mtp-info-box {
       padding: 1em;

--- a/mtp_noms_ops/assets-src/stylesheets/views/_security-results.scss
+++ b/mtp_noms_ops/assets-src/stylesheets/views/_security-results.scss
@@ -154,6 +154,6 @@
   }
 }
 
-#filter-prisoners .mtp-results-list-wrapper {
+#simple-search-prisoners .mtp-results-list-wrapper {
   margin-bottom: $gutter;
 }

--- a/mtp_noms_ops/templates/security/base_advanced_search.html
+++ b/mtp_noms_ops/templates/security/base_advanced_search.html
@@ -9,7 +9,7 @@
 {% block body_classes %}{{ block.super }} mtp-with-spaced-header{% endblock body_classes %}
 
 {% block inner_content %}
-  <form class="mtp-security-advanced-search mtp-autocomplete js-FormAnalytics" method="get">
+  <form id="advanced-search-{{ view.object_name_plural|slugify }}" class="mtp-security-advanced-search mtp-autocomplete js-FormAnalytics" method="get">
     <input type="hidden" name="{{ form.advanced.html_name }}" value="True" />
     <input type="hidden" name="{{ search_form_submitted_input_name }}" value="1" />
 

--- a/mtp_noms_ops/templates/security/credits_list.html
+++ b/mtp_noms_ops/templates/security/credits_list.html
@@ -4,7 +4,7 @@
 {% load security %}
 
 {% block inner_content %}
-  <form id="filter-credits" class="mtp-security-search js-FormAnalytics" method="get">
+  <form id="simple-search-{{ view.object_name_plural|slugify }}" class="mtp-security-search js-FormAnalytics" method="get">
 
     <div class="grid-row">
         <div class="column-two-thirds">

--- a/mtp_noms_ops/templates/security/disbursements_list.html
+++ b/mtp_noms_ops/templates/security/disbursements_list.html
@@ -4,7 +4,7 @@
 {% load security %}
 
 {% block inner_content %}
-  <form id="filter-disbursements" class="mtp-security-search js-FormAnalytics" method="get">
+  <form id="simple-search-{{ view.object_name_plural|slugify }}" class="mtp-security-search js-FormAnalytics" method="get">
 
     <div class="grid-row">
         <div class="column-two-thirds">

--- a/mtp_noms_ops/templates/security/prisoners_list.html
+++ b/mtp_noms_ops/templates/security/prisoners_list.html
@@ -4,7 +4,7 @@
 {% load security %}
 
 {% block inner_content %}
-  <form id="filter-prisoners" class="mtp-security-search js-FormAnalytics" method="get">
+  <form id="simple-search-{{ view.object_name_plural|slugify }}" class="mtp-security-search js-FormAnalytics" method="get">
     <div class="grid-row">
         <div class="column-two-thirds">
           {% include 'security/forms/top-area-object-list.html' %}

--- a/mtp_noms_ops/templates/security/senders_list.html
+++ b/mtp_noms_ops/templates/security/senders_list.html
@@ -4,7 +4,7 @@
 {% load security %}
 
 {% block inner_content %}
-  <form id="filter-senders" class="mtp-security-search js-FormAnalytics" method="get">
+  <form id="simple-search-{{ view.object_name_plural|slugify }}" class="mtp-security-search js-FormAnalytics" method="get">
 
     <div class="grid-row">
         <div class="column-two-thirds">


### PR DESCRIPTION
This:

**1/ Refactors the GA form events** 
We were sending one event per filter used with category name `SecurityForms`. 

We are now sending one event per filter used with category name `form-submitted-single-filter` PLUS one extra event with all combined filters used as a comma separated string with category name `form-submitted-combined-filters`.

Events are still sent using the legacy category name `SecurityForms` as well until we switch the search V2 on and we can safely delete it.

**2/ Renames export GA event to `form-link`**
We were using the event category `SecurityFormsExport` which wasn't great as it's supposed to be generic.

Events are still sent using the legacy category name `SecurityFormsExport` as well until we switch the search V2 on and we can safely delete it.

**3/ Refactors event category name for form errors**
GA form error events for Search V2 now use the category name `form-errors-<class-name>` so that it's obvious that it only logs errors and nothing else.