### PR TITLE
Only show first 2 prisons in advanced search results for senders

### DIFF
--- a/mtp_noms_ops/templates/security/senders_list.html
+++ b/mtp_noms_ops/templates/security/senders_list.html
@@ -119,7 +119,16 @@
                       </span>
                     </td>
                     {% if form.advanced.value %}
-                    <td>{{ sender.prisons|list_prison_names }}</td>
+                      {% get_split_prison_names sender.prisons 2 as split_prison_names %}
+                    <td>
+                      {{ split_prison_names.prison_names }}
+
+                      {% if split_prison_names.total_remaining %}
+                        {% blocktrans trimmed with total_remaining=split_prison_names.total_remaining %}
+                          and {{ total_remaining }} more
+                        {% endblocktrans %}
+                      {% endif %}
+                    </td>
                     {% else %}
                     <td class="numeric">
                       <span class="mtp-sortable-cell--pad">


### PR DESCRIPTION
Before we were showing the whole list which could be very long.
This implements the same logic used in other place where we only display the first 2 items with a 'x more' suffix.

**Before**

![Screenshot 2019-09-10 at 10 26 55](https://user-images.githubusercontent.com/178865/64602185-3ba9c080-d3b6-11e9-8455-d3ad7c634778.png)

**After**

![Screenshot 2019-09-10 at 10 26 14](https://user-images.githubusercontent.com/178865/64602201-406e7480-d3b6-11e9-8ad0-32a21da5394e.png)
