### PR TITLE
Add support for cloud platform migration

### DIFF
--- a/mtp_noms_ops/apps/security/context_processors.py
+++ b/mtp_noms_ops/apps/security/context_processors.py
@@ -28,7 +28,7 @@ def initial_params(request):
             ),
         }
 
-    if not request.user_prisons:
+    if not getattr(request, 'user_prisons', None):
         return {}
 
     return {'initial_params': urlencode([

--- a/mtp_noms_ops/settings/base.py
+++ b/mtp_noms_ops/settings/base.py
@@ -53,6 +53,7 @@ ROOT_URLCONF = 'mtp_noms_ops.urls'
 MIDDLEWARE_CLASSES = (
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.locale.LocaleMiddleware',
+    'mtp_common.cp_migration.middleware.CloudPlatformMigrationMiddleware',
     'django.middleware.common.CommonMiddleware',
     'mtp_common.auth.csrf.CsrfViewMiddleware',
     'mtp_common.auth.middleware.AuthenticationMiddleware',
@@ -280,6 +281,9 @@ NOMIS_API_PRIVATE_KEY = os.environ.get('NOMIS_API_PRIVATE_KEY', '').encode('utf8
 
 TOKEN_RETRIEVAL_USER = os.environ.get('TOKEN_RETRIEVAL_USER', '_token_retrieval')
 TOKEN_RETRIEVAL_PASSWORD = os.environ.get('TOKEN_RETRIEVAL_PASSWORD', '_token_retrieval')
+
+CLOUD_PLATFORM_MIGRATION_MODE = os.environ.get('CLOUD_PLATFORM_MIGRATION_MODE', '')
+CLOUD_PLATFORM_MIGRATION_URL = os.environ.get('CLOUD_PLATFORM_MIGRATION_URL', '')
 
 try:
     from .local import *  # noqa

--- a/mtp_noms_ops/utils.py
+++ b/mtp_noms_ops/utils.py
@@ -50,7 +50,10 @@ def external_breadcrumbs(request):
 
 def govuk_localisation(request):
     data = inherited_localisation(request)
-    if request.can_access_prisoner_location and not request.can_access_security:
+
+    can_access_prisoner_location = getattr(request, 'can_access_prisoner_location', False)
+    can_access_security = getattr(request, 'can_access_security', False)
+    if can_access_prisoner_location and not can_access_security:
         app_title = _('Prisoner location admin')
     else:
         app_title = _('Prisoner money intelligence')

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,4 +1,4 @@
 # Place development dependencies here
 -r base.txt
 
-money-to-prisoners-common[testing]>=9.10,<9.11
+money-to-prisoners-common[testing]>=9.11.1,<9.12

--- a/requirements/docker.txt
+++ b/requirements/docker.txt
@@ -1,6 +1,6 @@
 # Place docker dependencies here
 -r base.txt
 
-money-to-prisoners-common[monitoring]>=9.10,<9.11
+money-to-prisoners-common[monitoring]>=9.11.1,<9.12
 
 uWSGI==2.0.17


### PR DESCRIPTION
This adds the cloud platform migration middleware and sets up the related settings values as env vars.

There's one javascript error when the site is in maintenance or migration mode as `django` is not defined because of the missing `js-i18n.js`.

I'm not too worried about it as we don't really need any javascript (except ga) but I'm not sure if they would trigger sentry errors?

Fixing that is a bit painful but not too difficult and it probably requires changing https://github.com/ministryofjustice/money-to-prisoners-common/blob/master/mtp_common/assets-src/javascripts/modules/date-picker.js#L199 to support non-django-defined cases as well.

@ushkarev what do you think?

Update: fixed the data-picker.js to only init language strings when needed.