### PR TITLE
Remove feedback banner inclusion from search results page

### DIFF
--- a/mtp_noms_ops/templates/security/base_search_results.html
+++ b/mtp_noms_ops/templates/security/base_search_results.html
@@ -5,12 +5,6 @@
 
 {% block page_title %}{{ view.title }} – {{ block.super }}{% endblock %}
 
-{% block sub_nav %}
-  {{ block.super }}
-
-  {% include 'security/includes/feedback-banner.html' %}
-{% endblock %}
-
 {% block phase_banner %}
   {{ block.super }}
 

--- a/mtp_noms_ops/templates/security/includes/feedback-banner.html
+++ b/mtp_noms_ops/templates/security/includes/feedback-banner.html
@@ -1,6 +1,5 @@
 {% load i18n %}
 
-{% if not is_search_results %}
 <aside class="print-hidden mtp-feedback-banner">
   <div>
     <p class="font-medium">
@@ -9,4 +8,3 @@
     </p>
   </div>
 </aside>
-{% endif %}


### PR DESCRIPTION
The underlying logic is still in place in case we want to use the same banner for future features.