### PR TITLE
Only return pending checks related to credits in initial state

### DIFF
--- a/mtp_noms_ops/apps/security/forms/check.py
+++ b/mtp_noms_ops/apps/security/forms/check.py
@@ -3,6 +3,7 @@ import logging
 from functools import lru_cache
 
 from django import forms
+from django.conf import settings
 from django.utils import timezone
 from django.utils.functional import cached_property
 from django.utils.translation import gettext_lazy
@@ -47,6 +48,9 @@ class CheckListForm(SecurityForm):
         """
         params = super().get_api_request_params()
         params['status'] = 'pending'
+        # TODO: always add credit_resolution filter following delayed capture release
+        if settings.SHOW_ONLY_CHECKS_WITH_INITIAL_CREDIT:
+            params['credit_resolution'] = 'initial'
         return params
 
     def get_object_list_endpoint_path(self):

--- a/mtp_noms_ops/apps/security/tests/test_forms.py
+++ b/mtp_noms_ops/apps/security/tests/test_forms.py
@@ -6,7 +6,7 @@ from unittest import mock
 from urllib.parse import parse_qs
 
 from django import forms
-from django.test import SimpleTestCase
+from django.test import SimpleTestCase, override_settings
 from mtp_common.auth.test_utils import generate_tokens
 from mtp_common.test_utils import silence_logger
 import responses
@@ -2429,6 +2429,43 @@ class CheckListFormTestCase(SimpleTestCase):
                     'offset': ['20'],
                     'limit': ['20'],
                     'status': ['pending'],
+                },
+            )
+
+    @override_settings(SHOW_ONLY_CHECKS_WITH_INITIAL_CREDIT=True)
+    def test_get_object_list_with_initial_credits_only(self):
+        """
+        Test that the form makes the right API call to get the list of checks
+        when settings.SHOW_ONLY_CHECKS_WITH_INITIAL_CREDIT is set.
+        """
+        with responses.RequestsMock() as rsps:
+            rsps.add(
+                rsps.GET,
+                api_url('/security/checks/'),
+                json={
+                    'count': 0,
+                    'results': [],
+                },
+            )
+
+            form = CheckListForm(
+                self.request,
+                data={
+                    'page': 2,
+                },
+            )
+
+            self.assertTrue(form.is_valid())
+            self.assertListEqual(form.get_object_list(), [])
+
+            api_call_made = rsps.calls[-1].request.url
+            self.assertDictEqual(
+                parse_qs(api_call_made.split('?', 1)[1]),
+                {
+                    'offset': ['20'],
+                    'limit': ['20'],
+                    'status': ['pending'],
+                    'credit_resolution': ['initial'],
                 },
             )
 

--- a/mtp_noms_ops/settings/base.py
+++ b/mtp_noms_ops/settings/base.py
@@ -292,6 +292,8 @@ TOKEN_RETRIEVAL_PASSWORD = os.environ.get('TOKEN_RETRIEVAL_PASSWORD', '_token_re
 CLOUD_PLATFORM_MIGRATION_MODE = os.environ.get('CLOUD_PLATFORM_MIGRATION_MODE', '')
 CLOUD_PLATFORM_MIGRATION_URL = os.environ.get('CLOUD_PLATFORM_MIGRATION_URL', '')
 
+SHOW_ONLY_CHECKS_WITH_INITIAL_CREDIT = os.environ.get('SHOW_ONLY_CHECKS_WITH_INITIAL_CREDIT', 'False') == 'True'
+
 try:
     from .local import *  # noqa
 except ImportError:


### PR DESCRIPTION
This adds the ability to only include checks related to credits in initial state so that if payments time out, the linked checks don't show up.

It's behind a feature flag as we are currently running checks in simulation mode so if we enable this, none of the checks will appear.