### PR TITLE
Show form errors in search result page

### DIFF
--- a/mtp_noms_ops/templates/security/forms/top-area-object-list.html
+++ b/mtp_noms_ops/templates/security/forms/top-area-object-list.html
@@ -13,6 +13,8 @@
 
   {% include 'mtp_common/includes/message_box.html' %}
 
+  {% include 'mtp_common/forms/error-summary.html' with form=form only %}
+
   <p class="mtp-search-description">
     {% if objects %}
       {{ form.search_description.description }}


### PR DESCRIPTION
The previous version was hiding error messages related to API issues.