### PR TITLE
Add Job Information Form

### DIFF
--- a/mtp_noms_ops/apps/security/__init__.py
+++ b/mtp_noms_ops/apps/security/__init__.py
@@ -2,3 +2,4 @@ required_permissions = ['credit.view_credit', 'payment.view_payment', 'transacti
 hmpps_employee_flag = 'hmpps-employee'
 not_hmpps_employee_flag = 'not-hmpps-employee'
 confirmed_prisons_flag = 'confirmed-prisons'
+provided_job_info_flag = 'provided-job-information'

--- a/mtp_noms_ops/apps/security/urls.py
+++ b/mtp_noms_ops/apps/security/urls.py
@@ -8,10 +8,19 @@ from mtp_common.auth.api_client import get_api_session
 from mtp_noms_ops.utils import user_test
 from security import required_permissions, views
 from security.searches import get_saved_searches, populate_new_result_counts
-from security.utils import can_manage_security_checks, can_skip_confirming_prisons, is_hmpps_employee
+from security.utils import (
+    can_manage_security_checks,
+    can_skip_confirming_prisons,
+    is_hmpps_employee,
+    has_provided_job_information,
+)
 
 
 def security_test(view, extra_tests=None):
+    view = user_passes_test(
+        has_provided_job_information,
+        login_url='job_information',
+    )(view)
     view = user_passes_test(
         can_skip_confirming_prisons,
         login_url='confirm_prisons',

--- a/mtp_noms_ops/apps/security/utils.py
+++ b/mtp_noms_ops/apps/security/utils.py
@@ -179,7 +179,8 @@ def has_provided_job_information(user):
 
 
 def can_skip_confirming_prisons(user):
-    already_confirmed = confirmed_prisons_flag in user.user_data.get('flags', [])
+    flags = user.user_data.get('flags') or []
+    already_confirmed = confirmed_prisons_flag in flags
     cannot_choose_prisons = not can_choose_prisons(user)
     return already_confirmed or cannot_choose_prisons
 

--- a/mtp_noms_ops/apps/security/utils.py
+++ b/mtp_noms_ops/apps/security/utils.py
@@ -8,7 +8,7 @@ from django.utils.translation import gettext_lazy as _
 from mtp_common.auth import USER_DATA_SESSION_KEY
 from mtp_common.auth.api_client import get_api_session
 
-from security import hmpps_employee_flag, confirmed_prisons_flag
+from security import hmpps_employee_flag, confirmed_prisons_flag, provided_job_info_flag
 
 
 def convert_date_fields(object_list, include_nested=False):
@@ -171,6 +171,11 @@ def refresh_user_data(request, api_session=None):
 def is_hmpps_employee(user):
     flags = user.user_data.get('flags') or []
     return hmpps_employee_flag in flags
+
+
+def has_provided_job_information(user):
+    flags = user.user_data.get('flags') or []
+    return provided_job_info_flag in flags
 
 
 def can_skip_confirming_prisons(user):

--- a/mtp_noms_ops/apps/settings/forms.py
+++ b/mtp_noms_ops/apps/settings/forms.py
@@ -264,3 +264,44 @@ class ChangePrisonForm(ApiForm):
         query_dict = self.request.GET.copy()
         query_dict['prisons'] = prisons
         return urlencode(query_dict, doseq=True)
+
+
+class JobInformationForm(ApiForm):
+    job_titles = [
+        ('Evidence collator', _('Evidence collator')),
+        ('Intelligence analyst', _('Intelligence analyst')),
+        ('Intelligence officer', _('Intelligence officer')),
+        ('Intelligence researcher', _('Intelligence researcher')),
+        ('Intelligence support officer', _('Intelligence support officer')),
+        ('Safety analyst', _('Safety analyst')),
+        ('Security analyst', _('Security analyst')),
+        ('Other', _('Other'))
+    ]
+
+    prison_estates = [
+        ('Local prison', _('Local prison')),
+        ('Regional', _('Regional')),
+        ('National', _('National')),
+    ]
+    job_title = forms.ChoiceField(label=_('What is your job title?'),
+                                  choices=job_titles)
+    prison_estate = forms.ChoiceField(label=_('Which area of the prison estate do you work in?'),
+                                      choices=prison_estates)
+    tasks = forms.CharField(label=_('What are your main tasks?'),
+                            help_text=_('Give a brief description.'))
+
+    other_title = forms.CharField(max_length=100,
+                                  label=_('Tell us your job title'),
+                                  required=False)
+
+    def clean(self):
+        if 'job_title' in self.cleaned_data:
+            if self.cleaned_data['job_title'] == 'Other':
+                if self.cleaned_data['other_title'] == '':
+                    self.add_error('other_title', _('Please enter your job title'))
+                else:
+                    self.cleaned_data['job_title_or_other'] = self.cleaned_data['other_title']
+            else:
+                self.cleaned_data['job_title_or_other'] = self.cleaned_data['job_title']
+
+        return self.cleaned_data

--- a/mtp_noms_ops/apps/settings/tests/test_forms.py
+++ b/mtp_noms_ops/apps/settings/tests/test_forms.py
@@ -1,0 +1,48 @@
+from django.test import SimpleTestCase
+from settings.forms import JobInformationForm
+
+
+class JobInformationFormTestCase(SimpleTestCase):
+    def test_form_returns_error_when_no_other_job_title_given(self):
+        """Test that a form is not valid if no job title given when Other is selected"""
+
+        form = JobInformationForm({
+            'job_title': 'Other',
+            'prison_estate': 'Regional',
+            'tasks': 'Some tasks',
+        })
+
+        self.assertFalse(form.is_valid())
+        self.assertIn('Please enter your job title', form['other_title'].errors)
+
+    def test_form_returns_job_title_or_other_in_cleaned_data_when_other_selected(self):
+        form = JobInformationForm({
+            'job_title': 'Other',
+            'prison_estate': 'Regional',
+            'tasks': 'Some tasks',
+            'other_title': 'The Gaffer'
+        })
+
+        self.assertTrue(form.is_valid())
+        self.assertDictContainsSubset({'job_title_or_other': 'The Gaffer'}, form.cleaned_data)
+
+    def test_form_returns_job_title_or_other_in_cleaned_data_if_other_not_selected(self):
+        form = JobInformationForm({
+            'job_title': 'Intelligence officer',
+            'prison_estate': 'Regional',
+            'tasks': 'Some tasks',
+            'other_title': 'The Real Deal'
+        })
+
+        self.assertTrue(form.is_valid())
+        self.assertDictContainsSubset({'job_title_or_other': 'Intelligence officer'}, form.cleaned_data)
+
+    def test_form_invalid_with_no_data(self):
+        form = JobInformationForm({
+            'job_title': '',
+            'prison_estate': '',
+            'tasks': '',
+            'other_title': ''
+        })
+
+        self.assertFalse(form.is_valid())

--- a/mtp_noms_ops/apps/settings/tests/test_views.py
+++ b/mtp_noms_ops/apps/settings/tests/test_views.py
@@ -10,6 +10,7 @@ from security import (
     confirmed_prisons_flag,
     hmpps_employee_flag,
     required_permissions,
+    provided_job_info_flag,
 )
 from security.models import EmailNotifications
 from security.tests import api_url
@@ -45,7 +46,7 @@ class ConfirmPrisonTestCase(SecurityBaseTestCase):
     @responses.activate
     def test_does_not_redirect_after_confirmation(self):
         self.login(user_data=self.get_user_data(
-            flags=[hmpps_employee_flag, confirmed_prisons_flag])
+            flags=[hmpps_employee_flag, confirmed_prisons_flag, provided_job_info_flag])
         )
         response = self.client.get(reverse('security:dashboard'), follow=True)
         self.assertContains(response, '<!-- security:dashboard -->')
@@ -53,7 +54,7 @@ class ConfirmPrisonTestCase(SecurityBaseTestCase):
     @responses.activate
     def test_does_not_redirect_for_other_roles(self):
         self.login(user_data=self.get_user_data(
-            flags=[hmpps_employee_flag],
+            flags=[hmpps_employee_flag, provided_job_info_flag],
             roles=['security', 'prison-clerk'])
         )
         response = self.client.get(reverse('security:dashboard'), follow=True)
@@ -62,7 +63,7 @@ class ConfirmPrisonTestCase(SecurityBaseTestCase):
     @responses.activate
     def test_does_not_redirect_for_user_admin(self):
         self.login(user_data=self.get_user_data(
-            flags=[hmpps_employee_flag],
+            flags=[hmpps_employee_flag, provided_job_info_flag],
             permissions=required_permissions + ['auth.change_user'])
         )
         response = self.client.get(reverse('security:dashboard'), follow=True)

--- a/mtp_noms_ops/apps/settings/urls.py
+++ b/mtp_noms_ops/apps/settings/urls.py
@@ -3,7 +3,6 @@ from django.contrib.auth.decorators import login_required
 
 from . import views
 
-
 urlpatterns = [
     url(
         r'^$',
@@ -30,4 +29,9 @@ urlpatterns = [
         login_required(views.ConfirmPrisonsConfirmationView.as_view()),
         name='confirm_prisons_confirmation'
     ),
+    url(
+        r'^job_information/$',
+        login_required(views.JobInformationView.as_view()),
+        name='job_information'
+    )
 ]

--- a/mtp_noms_ops/assets-src/javascripts/modules/security-forms.js
+++ b/mtp_noms_ops/assets-src/javascripts/modules/security-forms.js
@@ -147,12 +147,14 @@ exports.SecurityForms = {
   init: function () {
     LegacySecurityForms.init();
 
-    if (!$('.mtp-security-advanced-search').length) {
-      return;
+    if ($('.mtp-security-advanced-search').length) {
+        this.bindConditionalShowHideSelection('amount_pattern');
+        this.bindConditionalShowHideSelection('prison_selector');
+        this.bindConditionalShowHideSelection('payment_method');
     }
-    this.bindConditionalShowHideSelection('amount_pattern');
-    this.bindConditionalShowHideSelection('prison_selector');
-    this.bindConditionalShowHideSelection('payment_method');
+    if ($('.mtp-job-information-form').length) {
+        this.bindConditionalShowHideSelection('job_title');
+    }
   },
 
   bindConditionalShowHideSelection: function (inputName) {

--- a/mtp_noms_ops/assets-src/stylesheets/app.scss
+++ b/mtp_noms_ops/assets-src/stylesheets/app.scss
@@ -18,6 +18,7 @@
 @import 'views/choose-prisons';
 @import 'views/prison_switcher';
 @import 'views/feedback-banner';
+@import 'views/job-information-form';
 
 // govuk elements overrides
 

--- a/mtp_noms_ops/assets-src/stylesheets/views/_job-information-form.scss
+++ b/mtp_noms_ops/assets-src/stylesheets/views/_job-information-form.scss
@@ -1,0 +1,11 @@
+.mtp-job-information-form {
+    .mtp-conditional-wrapper {
+        @extend .panel;
+        border-left-width: 5px;
+        margin-left: 18px;
+        padding: 0 0 0 26px;
+    }
+    #id_tasks {
+        width: 100%;
+    }
+}

--- a/mtp_noms_ops/templates/settings/job-information.html
+++ b/mtp_noms_ops/templates/settings/job-information.html
@@ -1,0 +1,99 @@
+{% extends 'base.html' %}
+{% load i18n %}
+{% load mtp_common %}
+
+{% block page_title %}
+  {{ view.title }}
+  –
+  {{ block.super }}
+{% endblock %}
+
+{% block inner_content %}
+
+  <header>
+    <h1 class="heading-xlarge">{{ view.title }}</h1>
+  </header>
+
+  {% include 'mtp_common/includes/message_box.html' %}
+
+  <div class="grid-row">
+    <div class="column-two-thirds">
+
+      <form method="post" class="mtp-job-information-form">
+        {% csrf_token %}
+
+        {% if form.errors %}
+          {% include 'mtp_common/forms/error-summary.html' with form=form only %}
+        {% endif %}
+
+        {% with field=form.job_title choices=form.job_title.field.choices %}
+          <fieldset class="mtp-conditional-container">
+            <legend id="{{ field.id_for_label }}-label">
+              <strong class="heading-large">{{ field.label }}</strong>
+            </legend>
+
+            <div class="form-group {% if field.errors %}form-group-error{% endif %}">
+            {% include 'mtp_common/forms/field-errors.html' with field=field only %}
+
+            {% with initial=value|default:field.value %}
+              {% for value, label in choices %}
+                <div class="multiple-choice">
+                  <input id="{{ field.html_name }}-{{ value|slugify }}" type="radio" name="{{ field.html_name }}" value="{{ value }}" {% if value == initial %}checked{% endif %}>
+                  <label for="{{ field.html_name }}-{{ value|slugify }}">{{ label }}</label>
+                </div>
+                {% if value == 'Other' %}
+                  <div class="mtp-conditional-wrapper" id="mtp-conditional-job_title-Other">
+                    {% include 'mtp_common/forms/field.html' with field=form.other_title only %}
+                  </div>
+                {% endif %}
+              {% endfor %}
+            {% endwith %}
+            </div>
+          </fieldset>
+        {% endwith %}
+
+        {% with field=form.prison_estate choices=form.prison_estate.field.choices %}
+          <fieldset>
+            <legend id="{{ field.id_for_label }}-label">
+              <strong class="heading-large">{{ field.label }}</strong>
+            </legend>
+
+            <div class="form-group {% if field.errors %}form-group-error{% endif %}">
+              {% include 'mtp_common/forms/field-errors.html' with field=field only %}
+              {% with initial=value|default:field.value %}
+                {% for value, label in choices %}
+                  <div class="multiple-choice">
+                    <input id="{{ field.html_name }}-{{ value|slugify }}" type="radio" name="{{ field.html_name }}" value="{{ value }}" {% if value == initial %}checked{% endif %}>
+                    <label for="{{ field.html_name }}-{{ value|slugify }}">{{ label }}</label>
+                  </div>
+                {% endfor %}
+              {% endwith %}
+            </div>
+          </fieldset>
+        {% endwith %}
+
+        {% with field=form.tasks %}
+          <fieldset>
+            <legend id="{{ field.id_for_label }}-label">
+              <strong class="heading-large">{{ field.label }}</strong>
+            </legend>
+            <div id="{{ field.id_for_label }}-wrapper" class="form-group {% if field.errors %}form-group-error{% endif %}">
+              <p class="form-hint">{{ field.help_text }}</p>
+              {% include 'mtp_common/forms/field-errors.html' with field=field only %}
+
+              <textarea id="{{ field.id_for_label }}" class="form-control {% if field.errors %}form-control-error{% endif %} {{ input_classes }}" name="{{ field.html_name }}" rows="4" cols="50" {% for attr, attr_val in attrs.items %} {{ attr }}="{{ attr_val }}" {% endfor %}>{{ value|default:field.value|default_if_none:'' }}</textarea>
+            </div>
+          </fieldset>
+        {% endwith %}
+
+        <div class="form-group">
+          <button type="submit" class="button">
+            {% trans 'Continue' %}
+          </button>
+        </div>
+      </form>
+
+    </div>
+  </div>
+
+{% endblock %}


### PR DESCRIPTION
## Questions/Notes

- ~I'm not happy with the early return in the Job Information `form_valid` method (see inline comment for details).~
- The templates in mtp-common didn't quite fit the requirements of the prototype/design - but we decided it wasn't worth updating them to be able to just include the templates for radios and textarea, a better plan is probably update them and make them more flexible when reworking them in the GDS styles update work.

## Commit message

### Add Job info form for collecting user research data

Jira: https://dsdmoj.atlassian.net/browse/MTP-1266

This commit adds a form to the Intelligence tool which will collect
information about an user's job title, the area of the prison estate
they work in and what their job title involves.

By using the flags used elsewhere in this app we only redirect a user
to a form if they have not previously completed the information.

We considered setting the user flag in the API but that would mean the
flag text had to be set in 2 places and given other flags are set in
this app when user actions occur (choosing prisons for instance) we
decided that this was the right choice.

The custom validation also ensures that if the user selects 'Other' form
the job title list, they still have to enter a job title to be able to
submit the form.
