### PR TITLE
Fix new code style error raised by flake8

### DIFF
--- a/mtp_noms_ops/apps/security/tests/test_views.py
+++ b/mtp_noms_ops/apps/security/tests/test_views.py
@@ -1140,7 +1140,7 @@ class ExportSecurityViewTestCaseMixin:
         taking any action.
         """
         # get realistic referer
-        qs = f'ordering=invalid'
+        qs = 'ordering=invalid'
         response = self.client.get('/')
         referer_url = response.wsgi_request.build_absolute_uri(
             f'{reverse(self.view_name)}?{qs}',


### PR DESCRIPTION
Flake8 complained about `./mtp_noms_ops/apps/security/tests/test_views.py:1143:14: F541 f-string is missing placeholders`
so just removing the formatting, as plain strings in tests don't need
it.

https://app.circleci.com/pipelines/github/ministryofjustice/money-to-prisoners-noms-ops/629/workflows/a5df5697-706b-486b-a0c3-05178c57ed1c/jobs/648

Still unsure why the failures appeared suddenly, flake8 config or something must have changed as I see no other reason for this cropping up where previously it was fine (for a long time)