### PR TITLE
Conditionally display decision details label

### DIFF
--- a/mtp_noms_ops/apps/security/tests/test_views.py
+++ b/mtp_noms_ops/apps/security/tests/test_views.py
@@ -2858,6 +2858,27 @@ class CreditsHistoryListViewTestCase(BaseCheckViewTestCase):
             self.assertContains(response, 'A0140QE')
             self.assertContains(response, 'accepted')
             self.assertContains(response, 'Brixton Prison')
+            self.assertContains(response, 'Decision details:')
+
+    def test_view_does_not_display_decision_if_none(self):
+        """
+        Test that the view displays the correct data from the API.
+        """
+        self.SAMPLE_CHECK_WITH_ACTIONED_BY['decision_reason'] = None
+
+        with responses.RequestsMock() as rsps:
+            self.login(rsps=rsps)
+            rsps.add(
+                rsps.GET,
+                api_url('/security/checks/'),
+                json={
+                    'count': 1,
+                    'results': [self.SAMPLE_CHECK_WITH_ACTIONED_BY],
+                },
+            )
+            response = self.client.get(reverse('security:credits_history'))
+
+            self.assertNotContains(response, 'Decision details:')
 
 
 class AcceptOrRejectCheckViewTestCase(BaseCheckViewTestCase):

--- a/mtp_noms_ops/templates/security/credits_history_list.html
+++ b/mtp_noms_ops/templates/security/credits_history_list.html
@@ -57,8 +57,10 @@
         <strong>{% trans 'Rule:' %}</strong>
         {{ check.description }}
         <br/>
-        <strong>{% trans 'Decision details:' %}</strong>
-        {{ check.decision_reason }}
+        {% if check.decision_reason %}
+          <strong>{% trans 'Decision details:' %}</strong>
+          {{ check.decision_reason }}
+        {% endif %}
       </td>
       <td>
         {{ check.credit.prisoner_number }}


### PR DESCRIPTION
If the decision reason is blank, as can be the case for accepted checks
we shouldn't show an empty label in the UI.