### PR TITLE
Disable submit button when prisoner location report is uploaded

### DIFF
--- a/mtp_noms_ops/assets-src/javascripts/main.js
+++ b/mtp_noms_ops/assets-src/javascripts/main.js
@@ -22,4 +22,5 @@
   require('autocomplete-select').AutocompleteSelect.init();
   require('choose-prisons').ChoosePrisons.init();
   require('form-analytics').FormAnalytics.init();
+  require('disable-on-submit').DisableOnSubmit.init();
 }());

--- a/mtp_noms_ops/assets-src/javascripts/modules/disable-on-submit.js
+++ b/mtp_noms_ops/assets-src/javascripts/modules/disable-on-submit.js
@@ -1,0 +1,18 @@
+// Disables forms on submit – used to prevent accidental concurrent submissions
+// NB: this temporary component will be replaced by a built-in one once this app is upgraded to the GDS design system
+'use strict';
+
+exports.DisableOnSubmit = {
+  selector: '.js-DisableOnSubmit',
+
+  init: function () {
+    $(this.selector).each(function () {
+      var $button = $(this);
+      var $form = $button.closest('form');
+
+      $form.submit(function () {
+        $button.prop('disabled', true);
+      });
+    });
+  }
+};

--- a/mtp_noms_ops/templates/prisoner_location_admin/location_file_upload.html
+++ b/mtp_noms_ops/templates/prisoner_location_admin/location_file_upload.html
@@ -41,7 +41,7 @@
   {% endwith %}
 
   <div class="form-group upload-control">
-    <input type="submit" value="{% trans 'Upload file' %}" class="button"/>
+    <input type="submit" value="{% trans 'Upload file' %}" class="button js-DisableOnSubmit" />
   </div>
   <p class="upload-otherfilelink"><a href=".">{% trans 'Upload another file' %}</a></p>
 </form>


### PR DESCRIPTION
…to prevent concurrent submission when users double-click. Concurrent submissions of this form result in incomplete lists of locations being stored.