### PR TITLE
Filter out irrelevant demo security checks

### DIFF
--- a/mtp_noms_ops/apps/security/forms/check.py
+++ b/mtp_noms_ops/apps/security/forms/check.py
@@ -32,7 +32,7 @@ class CheckListForm(SecurityForm):
         params = super().get_api_request_params()
         params['status'] = 'pending'
         # TODO: always add credit_resolution filter following delayed capture release
-            params['credit_resolution'] = 'initial'
+        params['credit_resolution'] = 'initial'
         return params
 
     def get_object_list_endpoint_path(self):
@@ -60,6 +60,7 @@ class CreditsHistoryListForm(SecurityForm):
     """
     List of security checks.
     """
+    CHECKS_STARTED = '2020-01-02T12:00:00'
 
     def get_api_request_params(self):
         """
@@ -67,6 +68,7 @@ class CreditsHistoryListForm(SecurityForm):
         """
         params = super().get_api_request_params()
         params['actioned_by'] = True
+        params['started_at__gte'] = self.CHECKS_STARTED
         return params
 
     def get_object_list_endpoint_path(self):

--- a/mtp_noms_ops/apps/security/forms/check.py
+++ b/mtp_noms_ops/apps/security/forms/check.py
@@ -69,6 +69,7 @@ class CreditsHistoryListForm(SecurityForm):
         params = super().get_api_request_params()
         params['actioned_by'] = True
         params['started_at__gte'] = self.CHECKS_STARTED
+        params['ordering'] = '-created'
         return params
 
     def get_object_list_endpoint_path(self):

--- a/mtp_noms_ops/apps/security/forms/check.py
+++ b/mtp_noms_ops/apps/security/forms/check.py
@@ -2,7 +2,6 @@ import logging
 from functools import lru_cache
 
 from django import forms
-from django.conf import settings
 from django.utils.functional import cached_property
 from django.utils.translation import gettext_lazy
 from form_error_reporting import GARequestErrorReportingMixin
@@ -33,7 +32,6 @@ class CheckListForm(SecurityForm):
         params = super().get_api_request_params()
         params['status'] = 'pending'
         # TODO: always add credit_resolution filter following delayed capture release
-        if settings.SHOW_ONLY_CHECKS_WITH_INITIAL_CREDIT:
             params['credit_resolution'] = 'initial'
         return params
 

--- a/mtp_noms_ops/apps/security/tests/test_forms.py
+++ b/mtp_noms_ops/apps/security/tests/test_forms.py
@@ -6,7 +6,7 @@ from unittest import mock
 from urllib.parse import parse_qs
 
 from django import forms
-from django.test import SimpleTestCase, override_settings
+from django.test import SimpleTestCase
 from django.utils.timezone import make_aware
 from django.utils.dateparse import parse_datetime
 from mtp_common.auth.test_utils import generate_tokens
@@ -2403,42 +2403,6 @@ class CheckListFormTestCase(SimpleTestCase):
     def test_get_object_list(self):
         """
         Test that the form makes the right API call to get the list of checks.
-        """
-        with responses.RequestsMock() as rsps:
-            rsps.add(
-                rsps.GET,
-                api_url('/security/checks/'),
-                json={
-                    'count': 0,
-                    'results': [],
-                },
-            )
-
-            form = CheckListForm(
-                self.request,
-                data={
-                    'page': 2,
-                },
-            )
-
-            self.assertTrue(form.is_valid())
-            self.assertListEqual(form.get_object_list(), [])
-
-            api_call_made = rsps.calls[-1].request.url
-            self.assertDictEqual(
-                parse_qs(api_call_made.split('?', 1)[1]),
-                {
-                    'offset': ['20'],
-                    'limit': ['20'],
-                    'status': ['pending'],
-                },
-            )
-
-    @override_settings(SHOW_ONLY_CHECKS_WITH_INITIAL_CREDIT=True)
-    def test_get_object_list_with_initial_credits_only(self):
-        """
-        Test that the form makes the right API call to get the list of checks
-        when settings.SHOW_ONLY_CHECKS_WITH_INITIAL_CREDIT is set.
         """
         with responses.RequestsMock() as rsps:
             rsps.add(

--- a/mtp_noms_ops/settings/base.py
+++ b/mtp_noms_ops/settings/base.py
@@ -292,8 +292,6 @@ TOKEN_RETRIEVAL_PASSWORD = os.environ.get('TOKEN_RETRIEVAL_PASSWORD', '_token_re
 CLOUD_PLATFORM_MIGRATION_MODE = os.environ.get('CLOUD_PLATFORM_MIGRATION_MODE', '')
 CLOUD_PLATFORM_MIGRATION_URL = os.environ.get('CLOUD_PLATFORM_MIGRATION_URL', '')
 
-SHOW_ONLY_CHECKS_WITH_INITIAL_CREDIT = os.environ.get('SHOW_ONLY_CHECKS_WITH_INITIAL_CREDIT', 'False') == 'True'
-
 try:
     from .local import *  # noqa
 except ImportError:


### PR DESCRIPTION
Before delayed capture functionality was enabled, there was a period during which checks were being created and automatically accepted as a preview for FIU. These should not appear in the history page since nobody "actioned" them.
[#MTP-1447](https://dsdmoj.atlassian.net/browse/MTP-1447)