### PR TITLE
MTP-1452 Add assign functionality for security checks

### DIFF
--- a/mtp_noms_ops/apps/security/urls.py
+++ b/mtp_noms_ops/apps/security/urls.py
@@ -370,6 +370,11 @@ urlpatterns = [
         name='resolve_check',
     ),
     url(
+        r'^security/checks/(?P<check_id>\d+)/assignment/$',
+        fiu_security_test(views.CheckAssignView.as_view()),
+        name='assign_check',
+    ),
+    url(
         r'^security/checks/history/$',
         fiu_security_test(views.CreditsHistoryListView.as_view()),
         name='credits_history',

--- a/mtp_noms_ops/apps/security/views/__init__.py
+++ b/mtp_noms_ops/apps/security/views/__init__.py
@@ -13,4 +13,4 @@ from .object_list import (  # noqa: F401
     NotificationListView,
 )
 from .review import ReviewCreditsView  # noqa: F401
-from .check import AcceptOrRejectCheckView, CheckListView, CreditsHistoryListView  # noqa: F401
+from .check import AcceptOrRejectCheckView, CheckListView, CreditsHistoryListView, CheckAssignView  # noqa: F401

--- a/mtp_noms_ops/assets-src/stylesheets/views/_checks.scss
+++ b/mtp_noms_ops/assets-src/stylesheets/views/_checks.scss
@@ -78,7 +78,6 @@ table.mtp-table--review {
   margin-bottom: 0.7rem;
 }
 
-
 .moj-sub-navigation__list {
   font-size: 0; // Removes white space when using inline-block on child element.
   box-shadow: inset 0 -1px 0 $grey-2;
@@ -87,7 +86,6 @@ table.mtp-table--review {
   padding: 0;
 
 }
-
 
 .moj-sub-navigation__item {
   line-height: 1.31579;
@@ -151,3 +149,19 @@ table.mtp-table--review {
 
 }
 
+.mtp-check-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+.mtp-check-header + .heading-medium {
+  margin-top: 0;
+}
+
+.mtp-check-header__list-toggle {
+  margin-bottom: 3.25rem;
+}
+
+.mtp-check-header__assigned-user {
+  color: $red;
+}

--- a/mtp_noms_ops/templates/security/accept_or_reject_check.html
+++ b/mtp_noms_ops/templates/security/accept_or_reject_check.html
@@ -7,140 +7,152 @@
 
 
 {% block inner_content %}
-  <header>
+  <header class="mtp-check-header">
     <h1 class="heading-xlarge">{{ view.title }}</h1>
+
+    <aside class="mtp-check-header__list-toggle print-hidden">
+      {% if check.assigned_to and check.assigned_to != request.user.pk %}
+        <strong class="mtp-check-header__assigned-user">{% trans 'Assigned to' %} {{ check.assigned_to_name }}</strong>
+      {% else %}
+        <form action="{% url 'security:assign_check' check_id=check.id %}" method="post">
+          {% csrf_token %}
+          {% if check.assigned_to %}
+            <button type="submit" name="assignment" class="button-secondary" value="unassign"> {% trans 'Remove from my List' %}</a>
+          {% else %}
+            <button type="submit" name="assignment" class="button-secondary" value="assign"> {% trans 'Add to my List' %}</a>
+          {% endif %}
+        </form>
+      {% endif %}
+    </aside>
   </header>
 
   {% include 'mtp_common/includes/message_box.html' %}
 
-  <form method="post">
-    {% csrf_token %}
-    {% include 'mtp_common/forms/error-summary.html' with form=form only %}
+  <h2 class="heading-medium">{% trans 'Credit details' %}</h2>
 
-    <h2 class="heading-medium">{% trans 'Credit details' %}</h2>
-    <div class="mtp-results-list table-font-xsmall mtp-check-list">
-      <table class="mtp-table mtp-table--review">
-        <thead>
-          <tr>
-            <th class="mtp-compact-cell">
-              <span class="visually-hidden">{% trans 'Needs attention?' %}</span>
-            </th>
-            <th>{% trans 'Date sent' %}</th>
-            <th>{% trans 'Debit card (from)' %}</th>
-            <th>{% trans 'Prisoner (to)' %}</th>
-            <th>{% trans 'Amount' %}</th>
-            <th class="print-hidden">{% trans 'Actions' %}</th>
-          </tr>
-        </thead>
-        <tbody>
+  <div class="mtp-results-list table-font-xsmall mtp-check-list">
+    <table class="mtp-table mtp-table--review">
+      <thead>
+        <tr>
+          <th class="mtp-compact-cell">
+            <span class="visually-hidden">{% trans 'Needs attention?' %}</span>
+          </th>
+          <th>{% trans 'Date sent' %}</th>
+          <th>{% trans 'Debit card (from)' %}</th>
+          <th>{% trans 'Prisoner (to)' %}</th>
+          <th>{% trans 'Amount' %}</th>
+          <th class="print-hidden">{% trans 'Actions' %}</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr class="mtp-check-row">
+          <td class="mtp-compact-cell">
+            {% if check.needs_attention %}
+              <span class="visually-hidden">
+                {% trans 'This credit needs attention today!' %}
+              </span>
+              <span class="mtp-check-needs-attention" aria-hidden="true">!</span>
+            {% else %}
+              <span class="visually-hidden">
+                {% trans 'This credit does not need attention today.' %}
+              </span>
+            {% endif %}
+          </td>
+          <td class="mtp-check-date">
+            {{ check.credit.started_at|date:'SHORT_DATETIME_FORMAT'}}
+          </td>
+          <td>
+            <a href="{{ check.credit|sender_profile_search_url }}" class="mtp-print-url-hidden">{{ check.credit.sender_name }}</a>
+            <br/>
+            {{ check.credit|format_card_number }} &nbsp; {{ check.credit.card_expiry_date }}
+            <br />
+            {{ check.credit.sender_email }}
+            <br />
+            {{ check.credit.billing_address.postcode }}
+          </td>
+          <td>
+            <a href="{{ check.credit|prisoner_profile_search_url }}" class="mtp-print-url-hidden">{{ check.credit.prisoner_name }}</a>
+            <br/>
+            {{ check.credit.prisoner_number }}
+            <br />
+            {{ check.credit.prison_name }}
+          </td>
+          <td>
+            {{ check.credit.amount|currency }}
+          </td>
+          <td class="print-hidden">
+            {{ check.status|format_security_check_status }}
+          </td>
+        </tr>
+        <tr class="mtp-check-description-row">
+          <td colspan="2"></td>
+          <td colspan="4">{{ check.description }}</td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+
+  <h3 class="heading-medium">{% trans 'Credit decisions matching debit card or prisoner' %}</h3>
+  <div class="mtp-results-list table-font-xsmall mtp-check-list">
+    <table class="mtp-table mtp-table--review">
+      <caption class=visually-hidden>{% trans 'This is a table showing any previous credit decisions involving the prisoner or debit card in question' %}</caption>
+      <thead>
+        <tr>
+          <th>{% trans 'Date sent' %}</th>
+          <th>{% trans 'Debit card (from)' %}</th>
+          <th>{% trans 'Prisoner (to)' %}</th>
+          <th>{% trans 'Amount' %}</th>
+          <th>{% trans 'Decision' %}</th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for credit in related_credits %}
           <tr class="mtp-check-row">
-            <td class="mtp-compact-cell">
-              {% if check.needs_attention %}
-                <span class="visually-hidden">
-                  {% trans 'This credit needs attention today!' %}
-                </span>
-                <span class="mtp-check-needs-attention" aria-hidden="true">!</span>
-              {% else %}
-                <span class="visually-hidden">
-                  {% trans 'This credit does not need attention today.' %}
-                </span>
-              {% endif %}
-            </td>
             <td class="mtp-check-date">
-              {{ check.credit.started_at|date:'SHORT_DATETIME_FORMAT'}}
+              {{ credit.started_at|date:'SHORT_DATETIME_FORMAT' }}
             </td>
             <td>
-              <a href="{{ check.credit|sender_profile_search_url }}" class="mtp-print-url-hidden">{{ check.credit.sender_name }}</a>
+              <a href="{{ credit|sender_profile_search_url }}" class="mtp-print-url-hidden">{{ credit.sender_name }}</a>
               <br/>
-              {{ check.credit|format_card_number }} &nbsp; {{ check.credit.card_expiry_date }}
+              {{ credit|format_card_number }}
               <br />
-              {{ check.credit.sender_email }}
+              {{ credit.card_expiry_date }}
               <br />
-              {{ check.credit.billing_address.postcode }}
+              {{ credit.sender_email }}
+              <br />
+              {{ credit.billing_address.postcode }}
             </td>
             <td>
-              <a href="{{ check.credit|prisoner_profile_search_url }}" class="mtp-print-url-hidden">{{ check.credit.prisoner_name }}</a>
+              <a href="{{ credit|prisoner_profile_search_url }}" class="mtp-print-url-hidden">{{ credit.prisoner_name }}</a>
               <br/>
-              {{ check.credit.prisoner_number }}
+              {{ credit.prisoner_number }}
               <br />
-              {{ check.credit.prison_name }}
+              {{ credit.prison_name }}
             </td>
             <td>
-              {{ check.credit.amount|currency }}
+              {{ credit.amount|currency }}
             </td>
-            <td class="print-hidden">
-              {{ check.status|format_security_check_status }}
+            <td>
+              <span class="mtp-check-status-tag mtp-check-status-tag--{{ credit.security_check.status }}">
+                {{ credit.security_check.status|format_security_check_status }}
+              </span>
+              <br />
+              {% trans 'by' %}
+              {{ credit.security_check.actioned_by_name }}
             </td>
           </tr>
           <tr class="mtp-check-description-row">
-            <td colspan="2"></td>
-            <td colspan="4">{{ check.description }}</td>
-          </tr>
-        </tbody>
-      </table>
-    </div>
-
-    <h3 class="heading-medium">{% trans 'Credit decisions matching debit card or prisoner' %}</h3>
-    <div class="mtp-results-list table-font-xsmall mtp-check-list">
-      <table class="mtp-table mtp-table--review">
-        <caption class=visually-hidden>{% trans 'This is a table showing any previous credit decisions involving the prisoner or debit card in question' %}</caption>
-        <thead>
-          <tr>
-            <th>{% trans 'Date sent' %}</th>
-            <th>{% trans 'Debit card (from)' %}</th>
-            <th>{% trans 'Prisoner (to)' %}</th>
-            <th>{% trans 'Amount' %}</th>
-            <th>{% trans 'Decision' %}</th>
-          </tr>
-        </thead>
-        <tbody>
-          {% for credit in related_credits %}
-            <tr class="mtp-check-row">
-              <td class="mtp-check-date">
-                {{ credit.started_at|date:'SHORT_DATETIME_FORMAT' }}
-              </td>
-              <td>
-                <a href="{{ credit|sender_profile_search_url }}" class="mtp-print-url-hidden">{{ credit.sender_name }}</a>
-                <br/>
-                {{ credit|format_card_number }}
-                <br />
-                {{ credit.card_expiry_date }}
-                <br />
-                {{ credit.sender_email }}
-                <br />
-                {{ credit.billing_address.postcode }}
-              </td>
-              <td>
-                <a href="{{ credit|prisoner_profile_search_url }}" class="mtp-print-url-hidden">{{ credit.prisoner_name }}</a>
-                <br/>
-                {{ credit.prisoner_number }}
-                <br />
-                {{ credit.prison_name }}
-              </td>
-              <td>
-                {{ credit.amount|currency }}
-              </td>
-              <td>
-                <span class="mtp-check-status-tag mtp-check-status-tag--{{ credit.security_check.status }}">
-                  {{ credit.security_check.status|format_security_check_status }}
-                </span>
-                <br />
-                {% trans 'by' %}
-                {{ credit.security_check.actioned_by_name }}
-              </td>
-            </tr>
-            <tr class="mtp-check-description-row">
-              <td></td>
-              <td colspan="4">
-                {{ credit.security_check.description }}
-                <br />
-                <br />
-                <strong>{% trans 'Decision details' %}:</strong>
-                {% if credit.security_check.decision_reason %}
-                  {{ credit.security_check.decision_reason }}
-                {% else %}
-                  {% trans 'No decision reason entered' %}
-                {% endif %}
+            <td></td>
+            <td colspan="4">
+              {{ credit.security_check.description }}
+              <br />
+              <br />
+              <strong>{% trans 'Decision details' %}:</strong>
+              {% if credit.security_check.decision_reason %}
+                {{ credit.security_check.decision_reason }}
+              {% else %}
+                {% trans 'No decision reason entered' %}
+              {% endif %}
               </td>
             </tr>
           {% empty %}
@@ -152,38 +164,44 @@
       </table>
     </div>
 
-    {% if check.status == 'pending' %}
+    <form id="accept-or-reject-form" method="post" action="{% url 'security:resolve_check' check_id=check.id %}#accept-or-reject-form">
+      {% csrf_token %}
+      {% include 'mtp_common/forms/error-summary.html' with form=form only %}
 
-      <h2 class="heading-medium">{% trans 'Your decision' %}</h2>
-      <div class="form-group">
-        {% include 'mtp_common/forms/textarea.html' with field=form.decision_reason input_classes='form-control-3-4' %}
-        <button type="submit" class="button" name="fiu_action" value="accept">
-          {% trans 'Accept credit' %}
-        </button>
-        <button type="submit" class="button button-warning" name="fiu_action" value="reject">
-          {% trans 'Reject credit' %}
-        </button>
-      </div>
+      {% if check.status == 'pending' %}
 
-    {% else %}
+        <div class="form-group">
+          <h2 class="heading-medium">{% trans 'Your decision' %}</h2>
+          <div class="form-group">
+            {% include 'mtp_common/forms/textarea.html' with field=form.decision_reason input_classes='form-control-3-4' %}
+            <button type="submit" class="button" name="fiu_action" value="accept">
+              {% trans 'Accept credit' %}
+            </button>
+            <button type="submit" class="button button-warning" name="fiu_action" value="reject">
+              {% trans 'Reject credit' %}
+            </button>
+          </div>
+        </div>
 
-      <h2 class="heading-medium">{% trans 'Decision' %}</h2>
-      <p>
-        {% blocktrans trimmed with resolved=check.status|format_security_check_status|lower user=check.actioned_by_name %}
-          This credit was {{ resolved }} by {{ user }}.
-        {% endblocktrans %}
-      </p>
-      <p>
-        <strong>{% trans 'Decision details' %}:</strong>
-        {% if check.decision_reason %}
-          {{ check.decision_reason }}
-        {% else %}
-          {% trans 'No decision reason entered' %}
-        {% endif %}
-      </p>
+      {% else %}
 
-    {% endif %}
+        <h2 class="heading-medium">{% trans 'Decision' %}</h2>
+        <p>
+          {% blocktrans trimmed with resolved=check.status|format_security_check_status|lower user=check.actioned_by_name %}
+            This credit was {{ resolved }} by {{ user }}.
+          {% endblocktrans %}
+        </p>
+        <p>
+          <strong>{% trans 'Decision details' %}:</strong>
+          {% if check.decision_reason %}
+            {{ check.decision_reason }}
+          {% else %}
+            {% trans 'No decision reason entered' %}
+          {% endif %}
+        </p>
 
-  </form>
+      {% endif %}
+
+    </form>
 
 {% endblock %}


### PR DESCRIPTION
## Questions

1. Is this approach a decent thing? Wasn't sure about just having redirects as the handling of the view
2. Will this handle invalid forms? I can't think of a case where the form would be invalid, but guess there could be things I missed
3. Are the tests comprehensive enough - I feel like I have nothing connecting actually hitting the button on the AcceptRejectView

Jira: https://dsdmoj.atlassian.net/browse/MTP-1452

This commit adds the ability to assign a check to a user so that they
can manage the checks they are or want to work on.

As there is no interface and it's initially just going to be done on the
Resolve credit page, we handle the form using a view that will just
redirect back to the resolve_check view.

The handling of GET requests is to get round an issue where django will
redirect a user after logging in to the assign view page with a GET
request if they click the add/remove check button, but their session has
expired.