### PR TITLE
Update Prison API (i.e. NOMIS) connector url handling

### DIFF
--- a/mtp_noms_ops/settings/base.py
+++ b/mtp_noms_ops/settings/base.py
@@ -278,9 +278,10 @@ LOCATION_UPLOADER_PASSWORD = os.environ.get('LOCATION_UPLOADER_PASSWORD', 'priso
 ASYNC_LOCATION_UPLOAD = os.environ.get('ASYNC_LOCATION_UPLOAD', 'True') == 'True'
 SHOW_LANGUAGE_SWITCH = os.environ.get('SHOW_LANGUAGE_SWITCH', 'False') == 'True'
 
-NOMIS_ELITE_CLIENT_ID = os.environ.get('NOMIS_ELITE_CLIENT_ID', '')
-NOMIS_ELITE_CLIENT_SECRET = os.environ.get('NOMIS_ELITE_CLIENT_SECRET', '')
-NOMIS_ELITE_BASE_URL = os.environ.get('NOMIS_ELITE_BASE_URL', '')
+HMPPS_CLIENT_ID = os.environ.get('HMPPS_CLIENT_ID', 'prisoner-money')
+HMPPS_CLIENT_SECRET = os.environ.get('HMPPS_CLIENT_SECRET', '')
+HMPPS_AUTH_BASE_URL = os.environ.get('HMPPS_AUTH_BASE_URL', '')
+HMPPS_PRISON_API_BASE_URL = os.environ.get('HMPPS_PRISON_API_BASE_URL', '')
 
 TOKEN_RETRIEVAL_USERNAME = os.environ.get('TOKEN_RETRIEVAL_USERNAME', '_token_retrieval')
 TOKEN_RETRIEVAL_PASSWORD = os.environ.get('TOKEN_RETRIEVAL_PASSWORD', '_token_retrieval')

--- a/mtp_noms_ops/settings/base.py
+++ b/mtp_noms_ops/settings/base.py
@@ -278,10 +278,6 @@ LOCATION_UPLOADER_PASSWORD = os.environ.get('LOCATION_UPLOADER_PASSWORD', 'priso
 ASYNC_LOCATION_UPLOAD = os.environ.get('ASYNC_LOCATION_UPLOAD', 'True') == 'True'
 SHOW_LANGUAGE_SWITCH = os.environ.get('SHOW_LANGUAGE_SWITCH', 'False') == 'True'
 
-NOMIS_API_BASE_URL = os.environ.get('NOMIS_API_BASE_URL', '')
-NOMIS_API_CLIENT_TOKEN = os.environ.get('NOMIS_API_CLIENT_TOKEN', '')
-NOMIS_API_PRIVATE_KEY = os.environ.get('NOMIS_API_PRIVATE_KEY', '').encode('utf8').decode('unicode_escape')
-
 NOMIS_ELITE_CLIENT_ID = os.environ.get('NOMIS_ELITE_CLIENT_ID', '')
 NOMIS_ELITE_CLIENT_SECRET = os.environ.get('NOMIS_ELITE_CLIENT_SECRET', '')
 NOMIS_ELITE_BASE_URL = os.environ.get('NOMIS_ELITE_BASE_URL', '')

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,5 +1,5 @@
 # Place development dependencies here
 -r base.txt
 
-money-to-prisoners-common[testing]>=9.18,<9.19
+money-to-prisoners-common[testing]>=9.19,<9.20
 watchdog>=0.9.0,<1

--- a/requirements/docker.txt
+++ b/requirements/docker.txt
@@ -1,6 +1,6 @@
 # Place docker dependencies here
 -r base.txt
 
-money-to-prisoners-common[monitoring]>=9.18,<9.19
+money-to-prisoners-common[monitoring]>=9.19,<9.20
 
 uWSGI==2.0.19.1


### PR DESCRIPTION
The new endpoint that HMPPS has chosen does not include `/elite2api/` in the URL. Because this is a breaking change and client apps must have updated settings, it seems safest to require new settings names entirely. The settings names are now more descriptive of what HMPPS is calling the associated components.

Depends on [common-383](https://github.com/ministryofjustice/money-to-prisoners-common/pull/383) and [deploy-305](https://github.com/ministryofjustice/money-to-prisoners-deploy/pull/305).

[MTP-1484](https://dsdmoj.atlassian.net/browse/MTP-1484)