### PR TITLE
MTP 1598 Post 2 nov banner updates

### DIFF
--- a/mtp_noms_ops/apps/security/tests/test_views.py
+++ b/mtp_noms_ops/apps/security/tests/test_views.py
@@ -4093,4 +4093,4 @@ class PolicyChangeViewTestCase(SecurityBaseTestCase):
     def test_displays_policy_update_page(self):
         self.login()
         response = self.client.get(reverse('security:policy_change'), follow=True)
-        self.assertContains(response, 'policy-change-info')
+        self.assertContains(response, 'policy-change-warning')

--- a/mtp_noms_ops/apps/security/tests/test_views.py
+++ b/mtp_noms_ops/apps/security/tests/test_views.py
@@ -4090,7 +4090,15 @@ class CheckAssignViewTestCase(BaseCheckViewTestCase, SecurityViewTestCase):
 
 class PolicyChangeViewTestCase(SecurityBaseTestCase):
     @responses.activate
-    def test_displays_policy_update_page(self):
+    @override_settings(NOVEMBER_SECOND_CHANGES_LIVE=False)
+    def test_displays_policy_warning_page_before_policy_change(self):
         self.login()
         response = self.client.get(reverse('security:policy_change'), follow=True)
         self.assertContains(response, 'policy-change-warning')
+
+    @responses.activate
+    @override_settings(NOVEMBER_SECOND_CHANGES_LIVE=True)
+    def test_displays_policy_update_page_after_policy_change(self):
+        self.login()
+        response = self.client.get(reverse('security:policy_change'), follow=True)
+        self.assertContains(response, 'policy-change-info')

--- a/mtp_noms_ops/apps/security/urls.py
+++ b/mtp_noms_ops/apps/security/urls.py
@@ -52,6 +52,7 @@ def dashboard_view(request):
     return render(request, 'dashboard.html', {
         'start_page_url': settings.START_PAGE_URL,
         'saved_searches': populate_new_result_counts(session, get_saved_searches(session)),
+        'november_second_changes_live': settings.NOVEMBER_SECOND_CHANGES_LIVE
     })
 
 

--- a/mtp_noms_ops/apps/security/views/object_list.py
+++ b/mtp_noms_ops/apps/security/views/object_list.py
@@ -1,4 +1,5 @@
 from django.urls import reverse
+from django.conf import settings
 from django.utils.translation import gettext_lazy as _
 
 from security.forms.object_list import (
@@ -59,6 +60,7 @@ class CreditListViewV2(SecuritySearchViewV2):
     object_name = _('credit')
     object_name_plural = _('credits')
     no_spaced_header = True
+    november_second_changes_live = settings.NOVEMBER_SECOND_CHANGES_LIVE
 
 
 class DisbursementListViewV2(SecuritySearchViewV2):
@@ -76,6 +78,7 @@ class DisbursementListViewV2(SecuritySearchViewV2):
     object_name = _('disbursement')
     object_name_plural = _('disbursements')
     no_spaced_header = True
+    november_second_changes_live = settings.NOVEMBER_SECOND_CHANGES_LIVE
 
 
 class SenderListViewV2(SecuritySearchViewV2):

--- a/mtp_noms_ops/apps/security/views/views.py
+++ b/mtp_noms_ops/apps/security/views/views.py
@@ -4,4 +4,4 @@ from django.views.generic import TemplateView
 
 class PolicyChangeView(TemplateView):
     title = _('Policy changes made on Nov 2nd 2020')
-    template_name = 'security/policy-change-info.html'
+    template_name = 'security/policy-change-warning.html'

--- a/mtp_noms_ops/apps/security/views/views.py
+++ b/mtp_noms_ops/apps/security/views/views.py
@@ -5,7 +5,7 @@ from django.views.generic import TemplateView
 
 class PolicyChangeView(TemplateView):
     if settings.NOVEMBER_SECOND_CHANGES_LIVE:
-        title = _('How Nov 2nd policy changes will affect you')
+        title = _('What the Nov 2nd policy changes mean')
     else:
         title = _('Policy changes made on Nov 2nd 2020')
 

--- a/mtp_noms_ops/apps/security/views/views.py
+++ b/mtp_noms_ops/apps/security/views/views.py
@@ -1,7 +1,16 @@
+from django.conf import settings
 from django.utils.translation import gettext_lazy as _
 from django.views.generic import TemplateView
 
 
 class PolicyChangeView(TemplateView):
-    title = _('Policy changes made on Nov 2nd 2020')
-    template_name = 'security/policy-change-warning.html'
+    if settings.NOVEMBER_SECOND_CHANGES_LIVE:
+        title = _('How Nov 2nd policy changes will affect you')
+    else:
+        title = _('Policy changes made on Nov 2nd 2020')
+
+    def get_template_names(self):
+        if settings.NOVEMBER_SECOND_CHANGES_LIVE:
+            return ['security/policy-change-info.html']
+        else:
+            return ['security/policy-change-warning.html']

--- a/mtp_noms_ops/settings/base.py
+++ b/mtp_noms_ops/settings/base.py
@@ -288,6 +288,30 @@ TOKEN_RETRIEVAL_PASSWORD = os.environ.get('TOKEN_RETRIEVAL_PASSWORD', '_token_re
 CLOUD_PLATFORM_MIGRATION_MODE = os.environ.get('CLOUD_PLATFORM_MIGRATION_MODE', '')
 CLOUD_PLATFORM_MIGRATION_URL = os.environ.get('CLOUD_PLATFORM_MIGRATION_URL', '')
 
+# Feature toggle for copy changes relating to bank transfers
+BANK_TRANSFERS_ENABLED = bool(
+    int(
+        os.environ.get(
+            'BANK_TRANSFERS_ENABLED',
+            '1'
+        )
+    )
+)
+
+# THIS SETTING OVERRIDES THE ABOVE SETTINGS
+NOVEMBER_SECOND_CHANGES_LIVE = bool(
+    int(
+        os.environ.get(
+            'NOVEMBER_SECOND_CHANGES_LIVE',
+            '0'
+        )
+    )
+)
+
+if NOVEMBER_SECOND_CHANGES_LIVE:
+    BANK_TRANSFERS_ENABLED = False
+    PRISONER_CAPPING_ENABLED = True
+
 try:
     from .local import *  # noqa
 except ImportError:

--- a/mtp_noms_ops/templates/dashboard.html
+++ b/mtp_noms_ops/templates/dashboard.html
@@ -24,21 +24,20 @@
     {% else %}
       <div class="mtp-notification mtp-notification--info">
         <h2 class="mtp-notification__headline">
-          {% trans 'How Nov 2nd policy changes will affect you' %}
+          {% trans 'What the Nov 2nd policy changes mean' %}
         </h2>
         <div class="mtp-notification__message" style="display:block">
 
           <h3><strong>{% trans 'Credits' %}</strong></h3>
-          <p>{% trans 'Senders will no longer be able to send money by bank transfer.' %}</p>
+          <p>{% trans 'Senders will no longer be able to send money by bank transfer or pre-paid card.' %}</p>
 
           <h3><strong>{% trans 'Disbursements' %}</strong></h3>
-          <p>{% trans 'There will be a cap on how much money can be sent out of prison.' %}</p>
-          <p>{% trans 'The cap will be a maximum of £50 a week sent out to each person.' %}</p>
+          <p>{% trans 'Prisoners can send out a maximum of £50 a week to up to 5 different people.' %}</p>
 
           <p><a href="{% url 'security:policy_change' %}">{% trans 'More details about Credit and Disbursement changes' %}</a></p>
 
           <h3><strong>{% trans 'Prisoner accounts' %}</strong></h3>
-          <p>{% trans 'There will be a cap of £900 on prisoner accounts.' %}</p>
+          <p>{% trans 'Credits will not be accepted into a prisoner’s account if it holds £900 or more.' %}</p>
         </div>
       </div>
     {% endif %}

--- a/mtp_noms_ops/templates/dashboard.html
+++ b/mtp_noms_ops/templates/dashboard.html
@@ -13,26 +13,35 @@
   {% notifications_box request 'noms_ops_security_dashboard' %}
 
   {% if request.can_access_security %}
-    <div class="mtp-notification mtp-notification--info">
-      <h2 class="mtp-notification__headline">
-        {% trans 'How Nov 2nd policy changes will affect you' %}
-      </h2>
-      <div class="mtp-notification__message" style="display:block">
+    {% if november_second_changes_live %}
+      <div class="mtp-notification mtp-notification--info mtp-notification--open">
+        <p class="mtp-notification__headline">
 
-        <h3><strong>{% trans 'Credits' %}</strong></h3>
-        <p>{% trans 'Senders will no longer be able to send money by bank transfer.' %}</p>
+          <a href="{% url 'security:policy_change' %}">{% trans 'Check you’re up to date with recent policy changes' %}</a>
 
-        <h3><strong>{% trans 'Disbursements' %}</strong></h3>
-        <p>{% trans 'There will be a cap on how much money can be sent out of prison.' %}</p>
-        <p>{% trans 'The cap will be a maximum of £50 a week sent out to each person.' %}</p>
-
-        <p><a href="{% url 'security:policy_change' %}">{% trans 'More details about Credit and Disbursement changes' %}</a></p>
-
-        <h3><strong>{% trans 'Prisoner accounts' %}</strong></h3>
-        <p>{% trans 'There will be a cap of £900 on prisoner accounts.' %}</p>
-
+        </p>
       </div>
-    </div>
+    {% else %}
+      <div class="mtp-notification mtp-notification--info">
+        <h2 class="mtp-notification__headline">
+          {% trans 'How Nov 2nd policy changes will affect you' %}
+        </h2>
+        <div class="mtp-notification__message" style="display:block">
+
+          <h3><strong>{% trans 'Credits' %}</strong></h3>
+          <p>{% trans 'Senders will no longer be able to send money by bank transfer.' %}</p>
+
+          <h3><strong>{% trans 'Disbursements' %}</strong></h3>
+          <p>{% trans 'There will be a cap on how much money can be sent out of prison.' %}</p>
+          <p>{% trans 'The cap will be a maximum of £50 a week sent out to each person.' %}</p>
+
+          <p><a href="{% url 'security:policy_change' %}">{% trans 'More details about Credit and Disbursement changes' %}</a></p>
+
+          <h3><strong>{% trans 'Prisoner accounts' %}</strong></h3>
+          <p>{% trans 'There will be a cap of £900 on prisoner accounts.' %}</p>
+        </div>
+      </div>
+    {% endif %}
   {% endif %}
 
   <header>

--- a/mtp_noms_ops/templates/security/credits_list.html
+++ b/mtp_noms_ops/templates/security/credits_list.html
@@ -5,12 +5,14 @@
 
 {% block inner_content %}
 
-  {% if not is_search_results %}
-    <div class="mtp-notification mtp-notification--info mtp-notification--open">
-      <h2 class="mtp-notification__headline">
-        <a href="{% url 'security:policy_change' %}">{% trans 'No more bank transfers' %}</a>
-      </h2>
-    </div>
+  {% if not view.november_second_changes_live %}
+    {% if not is_search_results %}
+      <div class="mtp-notification mtp-notification--info mtp-notification--open">
+        <h2 class="mtp-notification__headline">
+          <a href="{% url 'security:policy_change' %}">{% trans 'No more bank transfers' %}</a>
+        </h2>
+      </div>
+    {% endif %}
   {% endif %}
 
   <form id="simple-search-{{ view.object_name_plural|slugify }}" class="mtp-security-search js-FormAnalytics" method="get">

--- a/mtp_noms_ops/templates/security/disbursements_list.html
+++ b/mtp_noms_ops/templates/security/disbursements_list.html
@@ -6,8 +6,9 @@
 
 {% block inner_content %}
 
-{% static 'downloads/apply-to-send-out-more-than-50.pdf' as form_link %}
+  {% static 'downloads/apply-to-send-out-more-than-50.pdf' as form_link %}
 
+  {% if not view.november_second_changes_live %}
     {% if not is_search_results %}
       <div class="mtp-notification mtp-notification--info mtp-notification--open">
         <h2 class="mtp-notification__headline">
@@ -15,6 +16,7 @@
         </h2>
       </div>
     {% endif %}
+  {% endif %}
 
   <form id="simple-search-{{ view.object_name_plural|slugify }}" class="mtp-security-search js-FormAnalytics" method="get">
 

--- a/mtp_noms_ops/templates/security/policy-change-info.html
+++ b/mtp_noms_ops/templates/security/policy-change-info.html
@@ -13,36 +13,26 @@
 
   <!--[policy-change-info]-->
   <header>
-    <h1 class="heading-xlarge">{% trans 'How Nov 2nd policy changes will affect you' %}</h1>
+    <h1 class="heading-xlarge">{% trans 'Recent policy changes (Nov 2nd 2020) that may affect your work' %}</h1>
   </header>
 
   <div class="grid-row">
     <div class="column-two-thirds">
 
-      <h2 class="heading-large">{% trans 'No more bank transfers' %}</h2>
+      <h2 class="heading-large">{% trans 'Credits' %}</h2>
 
-      <p>{% trans 'A policy change from November 2nd means that senders have to ‘Send money to someone in prison’ using a debit card.' %}</p>
-      <p>{% trans 'They will no longer be able to send money by bank transfer or send in cash, cheques or postal orders by post.' %}</p>
-      <p>{% trans 'If they don’t have a bank account, we’re encouraging them to set one up. If they can’t use the service, they can apply to the governor for an ‘exemption’. ' %}</p>
-      <p>{% trans 'You may see a temporary rise in complaints because of these changes.' %}</p>
+      <p>{% trans 'Senders can only send money to a prisoner online using a debit card.' %}</p>
+      <p>{% trans 'They can no longer send money by bank transfer or pre-paid card.' %}</p>
+      <p>{% trans 'They can only send cash, cheque or postal order if they prove to the governor that they don’t have a bank account or can’t use the service.' %}</p>
 
-      <h2 class="heading-large">{% trans 'How the cap on disbursements works' %}</h2>
+      <h2 class="heading-large">{% trans 'Disbursements' %}</h2>
 
-      <h3 class="heading-medium">{% trans 'What is the disbursements cap?' %}</h3>
-      <p>{% trans 'A policy change from November 2nd means only £50 a week can be sent out to each person.' %}</p>
-      <p>{% trans 'Example: They can send up to £250 a week, if it’s to 5 different people.' %}</p>
-
-      <h3 class="heading-medium">{% trans 'If they want to send out more' %}</h3>
-      <p>{% trans 'A resident must apply for approval from the governor if they want to send more than £50 per person per week. In exceptional circumstances, this might be granted.' %}</p>
+      <p>{% trans 'Residents can only send out £50 a week to up to 5 different people, totalling £250.' %}</p>
       <p>
         {% blocktrans trimmed %}
-          It must be applied for each time by filling in a <a href="{{ form_link }}">form</a> which is attached to their disbursement before handing in.
+          A resident must apply for approval from the governor if they want to send more than £50 per person per week. Approval is granted only in exceptional circumstances. It must be applied for each time by filling in <a href="{{ form_link }}">a form</a> which they attach to their disbursement before handing in.
         {% endblocktrans %}
       </p>
-
-      <h2 class="heading-medium">{% trans 'What you need to do' %}</h3>
-      <p>{% trans 'If the resident’s application is approved, make the disbursement.' %}</p>
-      <p>{% trans 'If it is not approved, send the application form back with a reason why.' %}</p>
 
       <p>{% trans 'Exceptional circumstances could be:' %}</p>
 
@@ -53,6 +43,10 @@
         <li>{% trans 'operating a business, if unconvicted' %}</li>
         <li>{% trans 'transferring your money from prison to a new or existing bank account' %}</li>
       </ul>
+
+      <h2 class="heading-large">{% trans 'Prisoner bank accounts' %}</h2>
+
+      <p>{% trans 'Credits will not go into a prisoner’s account if it holds £900 or more.' %}</p>
 
     </div>
   </div>

--- a/mtp_noms_ops/templates/security/policy-change-warning.html
+++ b/mtp_noms_ops/templates/security/policy-change-warning.html
@@ -1,0 +1,59 @@
+{% extends 'base.html' %}
+{% load i18n %}
+{% load mtp_common %}
+{% load static %}
+
+{% block inner_content %}
+
+  {% static 'downloads/apply-to-send-out-more-than-50.pdf' as form_link %}
+
+  {% notifications_box request 'cashbook_dashboard' 'cashbook_all' %}
+
+  {% include 'mtp_common/includes/message_box.html' %}
+
+  <!--[policy-change-warning]-->
+  <header>
+    <h1 class="heading-xlarge">{% trans 'How Nov 2nd policy changes will affect you' %}</h1>
+  </header>
+
+  <div class="grid-row">
+    <div class="column-two-thirds">
+
+      <h2 class="heading-large">{% trans 'No more bank transfers' %}</h2>
+
+      <p>{% trans 'A policy change from November 2nd means that senders have to ‘Send money to someone in prison’ using a debit card.' %}</p>
+      <p>{% trans 'They will no longer be able to send money by bank transfer or send in cash, cheques or postal orders by post.' %}</p>
+      <p>{% trans 'If they don’t have a bank account, we’re encouraging them to set one up. If they can’t use the service, they can apply to the governor for an ‘exemption’. ' %}</p>
+      <p>{% trans 'You may see a temporary rise in complaints because of these changes.' %}</p>
+
+      <h2 class="heading-large">{% trans 'How the cap on disbursements works' %}</h2>
+
+      <h3 class="heading-medium">{% trans 'What is the disbursements cap?' %}</h3>
+      <p>{% trans 'A policy change from November 2nd means only £50 a week can be sent out to each person.' %}</p>
+      <p>{% trans 'Example: They can send up to £250 a week, if it’s to 5 different people.' %}</p>
+
+      <h3 class="heading-medium">{% trans 'If they want to send out more' %}</h3>
+      <p>{% trans 'A resident must apply for approval from the governor if they want to send more than £50 per person per week. In exceptional circumstances, this might be granted.' %}</p>
+      <p>
+        {% blocktrans trimmed %}
+          It must be applied for each time by filling in a <a href="{{ form_link }}">form</a> which is attached to their disbursement before handing in.
+        {% endblocktrans %}
+      </p>
+
+      <h2 class="heading-medium">{% trans 'What you need to do' %}</h3>
+      <p>{% trans 'If the resident’s application is approved, make the disbursement.' %}</p>
+      <p>{% trans 'If it is not approved, send the application form back with a reason why.' %}</p>
+
+      <p>{% trans 'Exceptional circumstances could be:' %}</p>
+
+      <ul class="list list-bullet">
+        <li>{% trans 'paying off debts if you have no external bank account' %}</li>
+        <li>{% trans 'sending financial support to family' %}</li>
+        <li>{% trans 'paying for a legitimate service, e.g. legal fees, dentistry' %}</li>
+        <li>{% trans 'operating a business, if unconvicted' %}</li>
+        <li>{% trans 'transferring your money from prison to a new or existing bank account' %}</li>
+      </ul>
+
+    </div>
+  </div>
+{% endblock %}

--- a/mtp_noms_ops/templates/security/policy-change-warning.html
+++ b/mtp_noms_ops/templates/security/policy-change-warning.html
@@ -40,10 +40,6 @@
         {% endblocktrans %}
       </p>
 
-      <h2 class="heading-medium">{% trans 'What you need to do' %}</h3>
-      <p>{% trans 'If the resident’s application is approved, make the disbursement.' %}</p>
-      <p>{% trans 'If it is not approved, send the application form back with a reason why.' %}</p>
-
       <p>{% trans 'Exceptional circumstances could be:' %}</p>
 
       <ul class="list list-bullet">

--- a/mtp_noms_ops/templates/security/policy-change-warning.html
+++ b/mtp_noms_ops/templates/security/policy-change-warning.html
@@ -13,7 +13,7 @@
 
   <!--[policy-change-warning]-->
   <header>
-    <h1 class="heading-xlarge">{% trans 'How Nov 2nd policy changes will affect you' %}</h1>
+    <h1 class="heading-xlarge">{% trans 'What the Nov 2nd policy changes mean' %}</h1>
   </header>
 
   <div class="grid-row">
@@ -21,16 +21,14 @@
 
       <h2 class="heading-large">{% trans 'No more bank transfers' %}</h2>
 
-      <p>{% trans 'A policy change from November 2nd means that senders have to ‘Send money to someone in prison’ using a debit card.' %}</p>
-      <p>{% trans 'They will no longer be able to send money by bank transfer or send in cash, cheques or postal orders by post.' %}</p>
-      <p>{% trans 'If they don’t have a bank account, we’re encouraging them to set one up. If they can’t use the service, they can apply to the governor for an ‘exemption’. ' %}</p>
-      <p>{% trans 'You may see a temporary rise in complaints because of these changes.' %}</p>
+      <p>{% trans 'Senders have to ‘Send money to someone in prison’ using a debit card.' %}</p>
+      <p>{% trans 'They will no longer be able to send money by bank transfer or pre-paid card.' %}</p>
+      <p>{% trans 'They can only send cash, cheque or postal order if they prove to the governor that they don’t have a bank account or can’t use the service.' %}</p>
 
       <h2 class="heading-large">{% trans 'How the cap on disbursements works' %}</h2>
 
       <h3 class="heading-medium">{% trans 'What is the disbursements cap?' %}</h3>
-      <p>{% trans 'A policy change from November 2nd means only £50 a week can be sent out to each person.' %}</p>
-      <p>{% trans 'Example: They can send up to £250 a week, if it’s to 5 different people.' %}</p>
+      <p>{% trans 'Residents will be able to send out a maximum of £50 a week to up to 5 different people, totalling £250.' %}</p>
 
       <h3 class="heading-medium">{% trans 'If they want to send out more' %}</h3>
       <p>{% trans 'A resident must apply for approval from the governor if they want to send more than £50 per person per week. In exceptional circumstances, this might be granted.' %}</p>


### PR DESCRIPTION
This is similar to the cashbook changes. I used the NOVEMBER_SECOND_CHANGES_LIVE changes rather thane BANK_TRANSFERS_ENABLED which is different to the cashbook, but I think this is better - but would it be better to have consistency for when it comes to removing these changes? I think it's OK, as it'll mostly just all be ripped out fairly soon, so shouldn't be too confusing.

