### PR TITLE
MTP-1700 Maintain current page in FIU Check List

### DIFF
--- a/mtp_noms_ops/apps/security/tests/test_views.py
+++ b/mtp_noms_ops/apps/security/tests/test_views.py
@@ -3739,13 +3739,39 @@ class CheckAssignViewTestCase(BaseCheckViewTestCase, SecurityViewTestCase):
                 }
             )
 
-            url = reverse('security:assign_check', kwargs={'check_id': check_id, 'list': 'list'})
+            url = reverse('security:assign_check', kwargs={'check_id': check_id, 'current_page': 1, 'list': 'list'})
 
             response = self.client.get(url, follow=True)
 
             self.assertRedirects(
-                response, reverse('security:check_list') + f'#check-row-{check_id}'
+                response, reverse('security:check_list') + f'?page=1#check-row-{check_id}'
             )
+
+    def test_assign_view_get_request_redirects_to_list_check_page_with_kwarg_and_current_page(self):
+        """
+        A GET request should redirect to the list page if called with 'list' as positional url arg
+        """
+        check_id = 1
+
+        with responses.RequestsMock() as rsps:
+            self.login(rsps=rsps)
+            rsps.add(
+                rsps.GET,
+                api_url('/security/checks/'),
+                json={
+                    'count': 21,
+                    'data': [self.SAMPLE_CHECK] * 21
+                }
+            )
+
+            url = reverse('security:assign_check', kwargs={'check_id': check_id, 'current_page': 2, 'list': 'list'})
+
+            response = self.client.get(url, follow=True)
+
+            self.assertRedirects(
+                response, reverse('security:check_list') + f'?page=2#check-row-{check_id}'
+            )
+            self.assertContains(response, 'Page 2 of 2')
 
     def test_can_assign_check_to_own_list(self):
         """

--- a/mtp_noms_ops/apps/security/urls.py
+++ b/mtp_noms_ops/apps/security/urls.py
@@ -376,7 +376,7 @@ urlpatterns = [
         name='resolve_check',
     ),
     url(
-        r'^security/checks/(?P<check_id>\d+)/assignment/(?P<list>\w+)?/?$',
+        r'^security/checks/(?P<check_id>\d+)/assignment/(?P<list>\w+)?/(?P<current_page>\d+)?/?$',
         fiu_security_test(views.CheckAssignView.as_view()),
         name='assign_check',
     ),

--- a/mtp_noms_ops/apps/security/views/check.py
+++ b/mtp_noms_ops/apps/security/views/check.py
@@ -20,6 +20,12 @@ class CheckListView(SecurityView):
     template_name = 'security/checks_list.html'
     form_class = CheckListForm
 
+    def get_context_data(self, **kwargs):
+        context_data = super().get_context_data(**kwargs)
+        context_data['current_page'] = self.request.GET.get('page', 1)
+
+        return context_data
+
 
 class MyListCheckView(SecurityView):
     """
@@ -45,10 +51,12 @@ class CheckAssignView(BaseFormView):
     """
     form_class = AssignCheckToUserForm
     id_kwarg_name = 'check_id'
+    page_kwarg_name = 'current_page'
 
     def get_success_url(self):
         if self.kwargs.get('list') == 'list':
-            return reverse('security:check_list') + f'#check-row-{self.kwargs[self.id_kwarg_name]}'
+            page_params = f'?page={self.kwargs[self.page_kwarg_name]}#check-row-{self.kwargs[self.id_kwarg_name]}'
+            return reverse('security:check_list') + page_params
         else:
             return reverse('security:resolve_check', kwargs={'check_id': self.kwargs[self.id_kwarg_name]})
 

--- a/mtp_noms_ops/templates/security/checks_list.html
+++ b/mtp_noms_ops/templates/security/checks_list.html
@@ -125,7 +125,7 @@
                       {% endblocktrans %}
                     </span>
                   {% else %}
-                    <form class="mtp-check-cell__list-form" action="{% url 'security:assign_check' check_id=check.id list='list' %}" method="post">
+                    <form class="mtp-check-cell__list-form" action="{% url 'security:assign_check' check_id=check.id current_page=current_page list='list' %}" method="post">
                       {% csrf_token %}
                       <button type="submit" name="assignment" class="button-secondary" value="assign">
                         {% blocktrans trimmed with credit_to=check.credit.prisoner_name %}


### PR DESCRIPTION
Jira: https://dsdmoj.atlassian.net/browse/MTP-1700

When an FIU user added a check to their list from a page other than the
first page, the user request would be actioned and the user redirected
back to the list view. However the page param was not maintained, and
the user would be sent back to page one, regardless of which page they
were currently on.

This commit addresses that by passing the current page through with the
check data to allow the redirect to maintain the current page for the
user.