### PR TITLE
Simpler python dependency tree

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,12 +11,12 @@ RUN set -ex; mkdir -p \
 
 # cache python packages, unless requirements change
 COPY ./requirements requirements
-RUN venv/bin/pip install -r requirements/docker.txt
+RUN venv/bin/pip install -r requirements/base.txt
 
 # add app and build it
 COPY . /app
 RUN set -ex; \
-  venv/bin/python run.py --requirements-file requirements/docker.txt build \
+  venv/bin/python run.py --requirements-file requirements/base.txt build \
   && \
   chown -R mtp:mtp /app
 USER 1000

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,11 +1,14 @@
 # Dependencies needed for all environments
-# NB: this is not the complete set needed to run the app
+
+money-to-prisoners-common~=10.1.0
+
 Django>=2.2,<2.3
 requests>=2.22,<3
 django-widget-tweaks>=1.4,<1.5
 transifex-client>=0.12
 django-anymail[mailgun]~=7.2
 openpyxl>=2.5,<2.6
+uWSGI==2.0.19.1
 
 django-form-error-reporting>=0.9
 django-moj-irat>=0.6

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -1,4 +1,5 @@
 # Place CI-only dependencies here
+
 -r dev.txt
 
 unittest-xml-reporting>=2.5,<3

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,7 +1,9 @@
-# Place development dependencies here
+# Place development and testing dependencies here
+
+money-to-prisoners-common[testing]~=10.1.0
+
 -r base.txt
 
-money-to-prisoners-common[testing]>=10.0.0,<10.1.0
 watchdog>=0.9.0,<1
 parameterized==0.7.4
 pdbpp

--- a/requirements/docker.txt
+++ b/requirements/docker.txt
@@ -1,6 +1,0 @@
-# Place docker dependencies here
--r base.txt
-
-money-to-prisoners-common[monitoring]>=10.0.0,<10.1.0
-
-uWSGI==2.0.19.1

--- a/run.py
+++ b/run.py
@@ -6,23 +6,27 @@ if __name__ == '__main__':
     if sys.version_info[0:2] < (3, 4):
         raise SystemExit('python 3.4+ is required')
 
+    root_path = os.path.abspath(os.path.dirname(__file__))
+
     try:
         import mtp_common
 
-        if mtp_common.VERSION < (5,):
+        # NB: this version does not need to be updated unless mtp_common changes significantly
+        if mtp_common.VERSION < (10,):
             raise ImportError
     except ImportError:
         try:
-            try:
-                from pip._internal import main as pip_main
-            except ImportError:
-                from pip import main as pip_main
+            import pkg_resources
         except ImportError:
             raise SystemExit('setuptools and pip are required')
+        try:
+            pip = pkg_resources.load_entry_point('pip', 'console_scripts', 'pip')
+        except pkg_resources.ResolutionError:
+            raise SystemExit('setuptools and pip are required')
 
-        print('Pre-installing MTP-common')
-        pip_main(['--quiet', 'install', '--upgrade', 'money-to-prisoners-common'])
+        print('Pre-installing MTP-common and base requirements')
+        pip(['install', '--requirement', f'{root_path}/requirements/base.txt'])
 
     from mtp_common.build_tasks.executor import Executor
 
-    exit(Executor(root_path=os.path.dirname(__file__)).run())
+    exit(Executor(root_path=root_path).run())

--- a/run.py
+++ b/run.py
@@ -3,8 +3,8 @@ if __name__ == '__main__':
     import os
     import sys
 
-    if sys.version_info[0:2] < (3, 4):
-        raise SystemExit('python 3.4+ is required')
+    if sys.version_info[0:2] < (3, 6):
+        raise SystemExit('Python 3.6+ is required')
 
     root_path = os.path.abspath(os.path.dirname(__file__))
 


### PR DESCRIPTION
Simplify python dependency tree by installing the correct version of mtp-common on _first run_ (i.e. when none is installed). This subsumes the dependencies for a production/deployed image into the base requirements which also simplifies testing.

Depends on [mtp-common#401](https://github.com/ministryofjustice/money-to-prisoners-common/pull/401)