### PR TITLE
MTP-1738 Add an auto-accept rule 

### DIFF
--- a/mtp_noms_ops/apps/security/constants.py
+++ b/mtp_noms_ops/apps/security/constants.py
@@ -21,6 +21,7 @@ CHECK_DETAIL_RENDERED_MAPPING = dict(
 
 CHECK_DETAIL_FORM_MAPPING = {
     'decision_reason': _('Give further details (optional)'),
+    'auto_accept_reason': _('Give reason for automatically accepting'),
     'rejection_reasons': dict(
         tuple(CHECK_REJECTION_CATEGORY_TEXT_MAPPING.items()) + tuple(CHECK_REJECTION_CATEGORY_BOOLEAN_MAPPING.items())
     )

--- a/mtp_noms_ops/apps/security/constants.py
+++ b/mtp_noms_ops/apps/security/constants.py
@@ -27,5 +27,6 @@ CHECK_DETAIL_FORM_MAPPING = {
     )
 }
 
+# This is as custom-defined exception within the API service that we match against
 CHECK_AUTO_ACCEPT_UNIQUE_CONSTRAINT_ERROR = \
     'An existing AutoAcceptRule is present for this DebitCardSenderDetails/PrisonerProfile pair'

--- a/mtp_noms_ops/apps/security/constants.py
+++ b/mtp_noms_ops/apps/security/constants.py
@@ -27,4 +27,4 @@ CHECK_DETAIL_FORM_MAPPING = {
     )
 }
 
-CHECK_AUTO_ACCEPT_UNIQUE_CONSTRAINT_ERROR = 'The fields debit_card_sender_details, prisoner_profile must make a unique set.'
+CHECK_AUTO_ACCEPT_UNIQUE_CONSTRAINT_ERROR = 'An existing AutoAcceptRule is present for this DebitCardSenderDetails/PrisonerProfile pair'

--- a/mtp_noms_ops/apps/security/constants.py
+++ b/mtp_noms_ops/apps/security/constants.py
@@ -27,4 +27,5 @@ CHECK_DETAIL_FORM_MAPPING = {
     )
 }
 
-CHECK_AUTO_ACCEPT_UNIQUE_CONSTRAINT_ERROR = 'An existing AutoAcceptRule is present for this DebitCardSenderDetails/PrisonerProfile pair'
+CHECK_AUTO_ACCEPT_UNIQUE_CONSTRAINT_ERROR = \
+    'An existing AutoAcceptRule is present for this DebitCardSenderDetails/PrisonerProfile pair'

--- a/mtp_noms_ops/apps/security/constants.py
+++ b/mtp_noms_ops/apps/security/constants.py
@@ -26,3 +26,5 @@ CHECK_DETAIL_FORM_MAPPING = {
         tuple(CHECK_REJECTION_CATEGORY_TEXT_MAPPING.items()) + tuple(CHECK_REJECTION_CATEGORY_BOOLEAN_MAPPING.items())
     )
 }
+
+CHECK_AUTO_ACCEPT_UNIQUE_CONSTRAINT_ERROR = 'The fields debit_card_sender_details, prisoner_profile must make a unique set.'

--- a/mtp_noms_ops/apps/security/forms/check.py
+++ b/mtp_noms_ops/apps/security/forms/check.py
@@ -9,7 +9,7 @@ from form_error_reporting import GARequestErrorReportingMixin
 from mtp_common.auth.api_client import get_api_session
 from requests.exceptions import RequestException
 
-from security.constants import CHECK_DETAIL_FORM_MAPPING
+from security.constants import CHECK_DETAIL_FORM_MAPPING, CHECK_AUTO_ACCEPT_UNIQUE_CONSTRAINT_ERROR
 from security.forms.object_base import SecurityForm
 from security.utils import convert_date_fields, get_need_attention_date
 
@@ -208,7 +208,8 @@ class AcceptOrRejectCheckForm(GARequestErrorReportingMixin, forms.Form):
             convert_dates_obj = convert_date_fields(obj, include_nested=True)
             convert_dates_obj['needs_attention'] = convert_dates_obj['credit']['started_at'] < self.need_attention_date
             return obj
-        except RequestException:
+        except RequestException as e:
+            self._handle_request_exception(e, 'Check')
             return None
 
     def get_object_endpoint_path(self):
@@ -287,25 +288,31 @@ class AcceptOrRejectCheckForm(GARequestErrorReportingMixin, forms.Form):
         return f'/security/checks/{self.object_id}/{fiu_action}/'
 
     def _handle_request_exception(self, e: RequestException, entity: str) -> bool:
+        error_payload = self._get_request_exception_payload(e)
+        return self._render_error_response(error_payload, entity)
+
+    def _render_error_response(self, error_payload, entity):
+        logger.exception('%s %s could not be actioned. Error payload: %s', entity, self.object_id, error_payload)
+        self.add_error(None, _('There was an error with your request.'))
+        return (False, '')
+
+    def _get_request_exception_payload(self, e: RequestException) -> dict:
         try:
             error_payload = e.response.json()
         except Exception:
             error_payload = {}
-        logger.exception('%s %s could not be actioned. Error payload: %s', entity, self.object_id, error_payload)
-        self.add_error(None, _('There was an error with your request.'))
-        return False
+        return error_payload
 
     def accept_or_reject(self):
         """
         Accepts or rejects the check via the API.
-        :return: True if the API call was successful.
-            If not, it returns False and populating the self.errors dict.
+        :rtype tuple(bool, str)
+        :returns: First element: True if the API call was successful. If not, False
+                  Second element: Additional information string to populate as message or empty string
         """
         fiu_action = self.cleaned_data.pop('fiu_action')
         endpoint = self.get_resolve_endpoint_path(fiu_action=fiu_action)
 
-        # TODO figure out what we should do in the case that we are unable to persist the auto-accept rule.
-        # Should we revert the state of the check via an update?
         try:
             self.session.post(
                 endpoint,
@@ -321,8 +328,8 @@ class AcceptOrRejectCheckForm(GARequestErrorReportingMixin, forms.Form):
                 check_auto_accept_rule_id = None
                 if check_auto_accept_rule_state:
                     check_auto_accept_rule_id = check_auto_accept_rule_state['auto_accept_rule']
-                try:
-                    if check_auto_accept_rule_id:
+                if check_auto_accept_rule_id:
+                    try:
                         # There is an auto-accept rule, which may be in the active or inactive state
                         self.session.patch(
                             f'/security/checks/auto-accept/{check_auto_accept_rule_id}',
@@ -333,7 +340,10 @@ class AcceptOrRejectCheckForm(GARequestErrorReportingMixin, forms.Form):
                                 }]
                             }
                         )
-                    else:
+                    except RequestException as e:
+                        return self._handle_request_exception(e, 'Auto Accept Rule')
+                else:
+                    try:
                         self.session.post(
                             '/security/checks/auto-accept',
                             json={
@@ -346,10 +356,27 @@ class AcceptOrRejectCheckForm(GARequestErrorReportingMixin, forms.Form):
                                 }]
                             }
                         )
-
-                except RequestException as e:
-                    return self._handle_request_exception(e, 'Auto Accept Rule')
-            return True
+                    except RequestException as e:
+                        error_response = self._get_request_exception_payload(e)
+                        if any(
+                                [
+                                    error_string == CHECK_AUTO_ACCEPT_UNIQUE_CONSTRAINT_ERROR
+                                    for error_string in error_response.get('non_field_errors', [])
+                                ]
+                        ):
+                            # TODO do we need to check if the auto-accept rule is active?
+                            # TODO are we happy that this check won't be linked to the existing auto-accept rule in the UI?
+                            return (
+                                True,
+                                'The auto-accept rule could not be created because an auto-accept rule '
+                                'already exists for {sender_name} and {prisoner_number}'.format(
+                                    sender_name=check['credit']['sender_name'],
+                                    prisoner_number=check['credit']['prisoner_number']
+                                )
+                            )
+                        else:
+                            return self._handle_request_exception(e, 'Auto Accept Rule')
+            return (True, '')
 
 
 class AssignCheckToUserForm(GARequestErrorReportingMixin, forms.Form):

--- a/mtp_noms_ops/apps/security/forms/check.py
+++ b/mtp_noms_ops/apps/security/forms/check.py
@@ -287,7 +287,7 @@ class AcceptOrRejectCheckForm(GARequestErrorReportingMixin, forms.Form):
     def get_resolve_endpoint_path(self, fiu_action='accept'):
         return f'/security/checks/{self.object_id}/{fiu_action}/'
 
-    def _handle_request_exception(self, e: RequestException, entity: str) -> bool:
+    def _handle_request_exception(self, e: RequestException, entity: str) -> tuple:
         error_payload = self._get_request_exception_payload(e)
         return self._render_error_response(error_payload, entity)
 
@@ -365,7 +365,7 @@ class AcceptOrRejectCheckForm(GARequestErrorReportingMixin, forms.Form):
                                 ]
                         ):
                             # TODO do we need to check if the auto-accept rule is active?
-                            # TODO are we happy that this check won't be linked to the existing auto-accept rule in the UI?
+                            # TODO we happy that this check won't be linked to the existing auto-accept rule in the UI?
                             return (
                                 True,
                                 'The auto-accept rule could not be created because an auto-accept rule '

--- a/mtp_noms_ops/apps/security/forms/check.py
+++ b/mtp_noms_ops/apps/security/forms/check.py
@@ -317,11 +317,15 @@ class AcceptOrRejectCheckForm(GARequestErrorReportingMixin, forms.Form):
             if fiu_action == 'accept' and self.cleaned_data.get('auto_accept_reason'):
                 # This shouldn't make another request due to the lru_cache decorator
                 check = self.get_object()
+                check_auto_accept_rule_state = check.get('auto_accept_rule_state', {})
+                check_auto_accept_rule_id = None
+                if check_auto_accept_rule_state:
+                    check_auto_accept_rule_id = check_auto_accept_rule_state['auto_accept_rule']
                 try:
-                    if check.get('auto_accept_rule'):
+                    if check_auto_accept_rule_id:
                         # There is an auto-accept rule, which may be in the active or inactive state
                         self.session.patch(
-                            f'/security/checks/auto-accept/{check["auto_accept_rule"]}',
+                            f'/security/checks/auto-accept/{check_auto_accept_rule_id}',
                             json={
                                 'states': [{
                                     'active': True,

--- a/mtp_noms_ops/apps/security/forms/check.py
+++ b/mtp_noms_ops/apps/security/forms/check.py
@@ -364,7 +364,6 @@ class AcceptOrRejectCheckForm(GARequestErrorReportingMixin, forms.Form):
                                     for error_string in error_response.get('non_field_errors', [])
                                 ]
                         ):
-                            # TODO do we need to check if the auto-accept rule is active?
                             # TODO we happy that this check won't be linked to the existing auto-accept rule in the UI?
                             return (
                                 True,

--- a/mtp_noms_ops/apps/security/tests/test_forms.py
+++ b/mtp_noms_ops/apps/security/tests/test_forms.py
@@ -2575,7 +2575,7 @@ class AcceptOrRejectCheckFormTestCase(SimpleTestCase):
             )
 
             self.assertTrue(form.is_valid())
-            self.assertEqual(form.accept_or_reject(), True)
+            self.assertEqual(form.accept_or_reject(), (True, ''))
 
     def test_form_invalid(self):
         """
@@ -2647,7 +2647,7 @@ class AcceptOrRejectCheckFormTestCase(SimpleTestCase):
             )
 
             self.assertTrue(form.is_valid())
-            self.assertEqual(form.accept_or_reject(), False)
+            self.assertEqual(form.accept_or_reject(), (False, ''))
             self.assertDictEqual(
                 form.errors,
                 {'__all__': ['There was an error with your request.']},
@@ -2688,7 +2688,7 @@ class AcceptOrRejectCheckFormTestCase(SimpleTestCase):
             )
 
             self.assertTrue(form.is_valid())
-            self.assertEqual(form.accept_or_reject(), True)
+            self.assertEqual(form.accept_or_reject(), (True, ''))
 
             last_request_body = json.loads(rsps.calls[-1].request.body)
             self.assertDictEqual(
@@ -2806,7 +2806,7 @@ class AcceptOrRejectCheckFormTestCase(SimpleTestCase):
             )
 
             self.assertTrue(form.is_valid())
-            self.assertEqual(form.accept_or_reject(), False)
+            self.assertEqual(form.accept_or_reject(), (False, ''))
             self.assertDictEqual(
                 form.errors,
                 {'__all__': ['There was an error with your request.']},

--- a/mtp_noms_ops/apps/security/tests/test_views.py
+++ b/mtp_noms_ops/apps/security/tests/test_views.py
@@ -2682,7 +2682,8 @@ class BaseCheckViewTestCase(SecurityBaseTestCase):
         'status': 'pending',
         'actioned_at': None,
         'actioned_by': None,
-        'assigned_to': 7
+        'assigned_to': 7,
+        'auto_accept_rule_state': None
     }
 
     SAMPLE_CREDIT_BASE = {
@@ -3873,7 +3874,9 @@ class AcceptOrRejectCheckViewTestCase(BaseCheckViewTestCase, SecurityViewTestCas
             'decision_reason': '',
         }
         check_with_inactive_auto_accept = copy.deepcopy(self.SENDER_CHECK)
-        check_with_inactive_auto_accept['auto_accept_rule'] = auto_accept_rule_id
+        check_with_inactive_auto_accept['auto_accept_rule_state'] = {
+            'auto_accept_rule': auto_accept_rule_id
+        }
         with responses.RequestsMock() as rsps:
             self.login(rsps=rsps)
             rsps.add(
@@ -3979,7 +3982,9 @@ class AcceptOrRejectCheckViewTestCase(BaseCheckViewTestCase, SecurityViewTestCas
             'decision_reason': '',
         }
         check_with_inactive_auto_accept = copy.deepcopy(self.SENDER_CHECK)
-        check_with_inactive_auto_accept['auto_accept_rule'] = auto_accept_rule_id
+        check_with_inactive_auto_accept['auto_accept_rule_state'] = {
+            'auto_accept_rule': auto_accept_rule_id
+        }
         auto_accept_payload_values = {
             'states': [{
                 'active': True,

--- a/mtp_noms_ops/apps/security/tests/test_views.py
+++ b/mtp_noms_ops/apps/security/tests/test_views.py
@@ -2679,6 +2679,19 @@ class BaseCheckViewTestCase(SecurityBaseTestCase):
 
     credit_created_date = datetime.datetime.now()
 
+    ACTIVE_AUTO_ACCEPT_RULE_STATE = {
+        'reason': 'Prisoners mother',
+        'active': True,
+        'added_by': {
+            'first_name': 'hello',
+            'last_name': 'kitty'
+        },
+        'auto_accept_rule': {
+            'debit_card_sender_details': 17,
+            'prisoner_profile': prisoner_id,
+        }
+    }
+
     SAMPLE_CHECK_BASE = {
         'id': 1,
         'description': 'lorem ipsum',
@@ -2706,7 +2719,7 @@ class BaseCheckViewTestCase(SecurityBaseTestCase):
         'credited_at': None,
         'prisoner_profile': prisoner_id,
         'billing_address': {
-            'debit_card_sender_details': 17
+            'debit_card_sender_details': ACTIVE_AUTO_ACCEPT_RULE_STATE['auto_accept_rule']['debit_card_sender_details']
         }
     }
 
@@ -2739,6 +2752,11 @@ class BaseCheckViewTestCase(SecurityBaseTestCase):
     SENDER_CHECK['credit']['billing_address'] = {'debit_card_sender_details': 42}
 
     SENDER_CHECK_REJECTED = dict(SENDER_CHECK, status='rejected')
+    SENDER_CHECK_ACCEPTED_WITH_RULE = dict(
+        SENDER_CHECK,
+        status='accepted',
+        auto_accept_rule_state=ACTIVE_AUTO_ACCEPT_RULE_STATE
+    )
 
     PRISONER_CREDIT = dict(
         SAMPLE_CREDIT_BASE,
@@ -3379,6 +3397,8 @@ class AcceptOrRejectCheckViewTestCase(BaseCheckViewTestCase, SecurityViewTestCas
         """
         response_len = 4
         check_id = 1
+        reason = 'Prisoners mother'
+        user_data = self.get_user_data(permissions=required_permissions)
         with responses.RequestsMock() as rsps:
             self.login(rsps)
             rsps.add(
@@ -3460,7 +3480,12 @@ class AcceptOrRejectCheckViewTestCase(BaseCheckViewTestCase, SecurityViewTestCas
                         },
                         {
                             'created': (datetime.datetime.now() - datetime.timedelta(hours=1)).isoformat(),
-                            'active': True
+                            'active': True,
+                            'reason': reason,
+                            'added_by': {
+                                'first_name': user_data['first_name'],
+                                'last_name': user_data['last_name'],
+                            }
                         },
                     ]
                 }]}
@@ -3473,6 +3498,13 @@ class AcceptOrRejectCheckViewTestCase(BaseCheckViewTestCase, SecurityViewTestCas
             self.assertContains(response, '123456******9876')
             self.assertContains(response, '02/20')
             self.assertNotContains(response, 'Automatically accept future credits from')
+            self.assertContains(
+                response,
+                f'This check is associated with an active auto-rule between '
+                f'{self.SENDER_CHECK["credit"]["sender_name"]} and {self.SENDER_CHECK["credit"]["prisoner_number"]}'
+                f' This rule was activated by {user_data["first_name"]} {user_data["last_name"]}. The reason given was '
+                f'{reason}'
+            )
 
     def test_get_with_previous_unbound_inactive_auto_accept(self):
         """
@@ -3585,7 +3617,7 @@ class AcceptOrRejectCheckViewTestCase(BaseCheckViewTestCase, SecurityViewTestCas
             rsps.add(
                 rsps.GET,
                 api_url(f'/security/checks/{check_id}/'),
-                json=self.SENDER_CHECK_REJECTED
+                json=self.SENDER_CHECK_ACCEPTED_WITH_RULE
             )
             rsps.add(
                 rsps.GET,
@@ -3618,10 +3650,12 @@ class AcceptOrRejectCheckViewTestCase(BaseCheckViewTestCase, SecurityViewTestCas
                 '{}/security/checks/auto-accept?{}/'.format(
                     settings.API_URL,
                     urlencode((
-                        ('prisoner_profile_id', self.SENDER_CHECK['credit']['prisoner_profile']),
+                        ('prisoner_profile_id', self.SENDER_CHECK_ACCEPTED_WITH_RULE['credit']['prisoner_profile']),
                         (
                             'debit_card_sender_details_id',
-                            self.SENDER_CHECK['credit']['billing_address']['debit_card_sender_details']
+                            self.SENDER_CHECK_ACCEPTED_WITH_RULE['credit']['billing_address'][
+                                'debit_card_sender_details'
+                            ]
                         )
                     ))
                 ),
@@ -3632,7 +3666,15 @@ class AcceptOrRejectCheckViewTestCase(BaseCheckViewTestCase, SecurityViewTestCas
             response = self.client.get(url)
         content = response.content.decode()
         self.assertNotIn('name="fiu_action"', content, msg='Action button exists on page')
-        self.assertIn('This credit was rejected by', content)
+        self.assertIn('This credit was accepted by', content)
+        self.assertContains(
+            response,
+            f'This check is associated with an active auto-rule between '
+            f'{self.SENDER_CHECK["credit"]["sender_name"]} and {self.SENDER_CHECK["credit"]["prisoner_number"]}'
+            f' This rule was activated by {self.ACTIVE_AUTO_ACCEPT_RULE_STATE["added_by"]["first_name"]} '
+            f'{self.ACTIVE_AUTO_ACCEPT_RULE_STATE["added_by"]["last_name"]}. The reason given was '
+            f'{self.ACTIVE_AUTO_ACCEPT_RULE_STATE["reason"]}'
+        )
 
     def test_check_view_includes_matching_credit_history(self):
         """

--- a/mtp_noms_ops/apps/security/tests/test_views.py
+++ b/mtp_noms_ops/apps/security/tests/test_views.py
@@ -3354,7 +3354,7 @@ class AcceptOrRejectCheckViewTestCase(BaseCheckViewTestCase, SecurityViewTestCas
             )
             rsps.add(
                 rsps.GET,
-                '{}/security/checks/auto-accept?{}/'.format(
+                '{}/security/checks/auto-accept/?{}'.format(
                     settings.API_URL,
                     urlencode((
                         ('prisoner_profile_id', self.SENDER_CHECK['credit']['prisoner_profile']),
@@ -3437,7 +3437,7 @@ class AcceptOrRejectCheckViewTestCase(BaseCheckViewTestCase, SecurityViewTestCas
             )
             rsps.add(
                 rsps.GET,
-                '{}/security/checks/auto-accept?{}/'.format(
+                '{}/security/checks/auto-accept/?{}'.format(
                     settings.API_URL,
                     urlencode((
                         ('prisoner_profile_id', self.SENDER_CHECK['credit']['prisoner_profile']),
@@ -3557,7 +3557,7 @@ class AcceptOrRejectCheckViewTestCase(BaseCheckViewTestCase, SecurityViewTestCas
             )
             rsps.add(
                 rsps.GET,
-                '{}/security/checks/auto-accept?{}/'.format(
+                '{}/security/checks/auto-accept/?{}'.format(
                     settings.API_URL,
                     urlencode((
                         ('prisoner_profile_id', self.SENDER_CHECK['credit']['prisoner_profile']),
@@ -3592,6 +3592,11 @@ class AcceptOrRejectCheckViewTestCase(BaseCheckViewTestCase, SecurityViewTestCas
             self.assertContains(response, '123456******9876')
             self.assertContains(response, '02/20')
             self.assertContains(response, 'Automatically accept future credits from')
+            self.assertNotContains(
+                response,
+                f'Auto accept started for credits from {self.SENDER_CHECK["credit"]["sender_name"]} to '
+                f'{self.SENDER_CHECK["credit"]["prisoner_number"]}'
+            )
 
     def test_check_view_hides_action_buttons_if_resolved_already(self):
         """
@@ -3637,7 +3642,7 @@ class AcceptOrRejectCheckViewTestCase(BaseCheckViewTestCase, SecurityViewTestCas
             )
             rsps.add(
                 rsps.GET,
-                '{}/security/checks/auto-accept?{}/'.format(
+                '{}/security/checks/auto-accept/?{}'.format(
                     settings.API_URL,
                     urlencode((
                         ('prisoner_profile_id', self.SENDER_CHECK['credit']['prisoner_profile']),
@@ -3717,7 +3722,7 @@ class AcceptOrRejectCheckViewTestCase(BaseCheckViewTestCase, SecurityViewTestCas
             )
             rsps.add(
                 rsps.GET,
-                '{}/security/checks/auto-accept?{}/'.format(
+                '{}/security/checks/auto-accept/?{}'.format(
                     settings.API_URL,
                     urlencode((
                         ('prisoner_profile_id', self.SENDER_CHECK['credit']['prisoner_profile']),
@@ -3834,7 +3839,7 @@ class AcceptOrRejectCheckViewTestCase(BaseCheckViewTestCase, SecurityViewTestCas
             )
             rsps.add(
                 rsps.GET,
-                '{}/security/checks/auto-accept?{}/'.format(
+                '{}/security/checks/auto-accept/?{}'.format(
                     settings.API_URL,
                     urlencode((
                         ('prisoner_profile_id', self.SENDER_CHECK['credit']['prisoner_profile']),
@@ -3932,7 +3937,7 @@ class AcceptOrRejectCheckViewTestCase(BaseCheckViewTestCase, SecurityViewTestCas
             )
             rsps.add(
                 rsps.GET,
-                '{}/security/checks/auto-accept?{}/'.format(
+                '{}/security/checks/auto-accept/?{}'.format(
                     settings.API_URL,
                     urlencode((
                         ('prisoner_profile_id', self.SENDER_CHECK['credit']['prisoner_profile']),
@@ -4028,7 +4033,7 @@ class AcceptOrRejectCheckViewTestCase(BaseCheckViewTestCase, SecurityViewTestCas
             )
             rsps.add(
                 rsps.GET,
-                '{}/security/checks/auto-accept?{}/'.format(
+                '{}/security/checks/auto-accept/?{}'.format(
                     settings.API_URL,
                     urlencode((
                         ('prisoner_profile_id', self.SENDER_CHECK['credit']['prisoner_profile']),
@@ -4126,7 +4131,7 @@ class AcceptOrRejectCheckViewTestCase(BaseCheckViewTestCase, SecurityViewTestCas
             )
             rsps.add(
                 rsps.GET,
-                '{}/security/checks/auto-accept?{}/'.format(
+                '{}/security/checks/auto-accept/?{}'.format(
                     settings.API_URL,
                     urlencode((
                         ('prisoner_profile_id', self.SENDER_CHECK['credit']['prisoner_profile']),
@@ -4543,7 +4548,7 @@ class AcceptOrRejectCheckViewTestCase(BaseCheckViewTestCase, SecurityViewTestCas
             )
             rsps.add(
                 rsps.GET,
-                '{}/security/checks/auto-accept?{}/'.format(
+                '{}/security/checks/auto-accept/?{}'.format(
                     settings.API_URL,
                     urlencode((
                         ('prisoner_profile_id', self.SENDER_CHECK['credit']['prisoner_profile']),
@@ -4629,7 +4634,7 @@ class AcceptOrRejectCheckViewTestCase(BaseCheckViewTestCase, SecurityViewTestCas
             )
             rsps.add(
                 rsps.GET,
-                '{}/security/checks/auto-accept?{}/'.format(
+                '{}/security/checks/auto-accept/?{}'.format(
                     settings.API_URL,
                     urlencode((
                         ('prisoner_profile_id', self.SENDER_CHECK['credit']['prisoner_profile']),
@@ -4790,7 +4795,7 @@ class CheckAssignViewTestCase(BaseCheckViewTestCase, SecurityViewTestCase):
             )
             rsps.add(
                 rsps.GET,
-                '{}/security/checks/auto-accept?{}/'.format(
+                '{}/security/checks/auto-accept/?{}'.format(
                     settings.API_URL,
                     urlencode((
                         ('prisoner_profile_id', self.SENDER_CHECK['credit']['prisoner_profile']),
@@ -4868,7 +4873,7 @@ class CheckAssignViewTestCase(BaseCheckViewTestCase, SecurityViewTestCase):
             )
             rsps.add(
                 rsps.GET,
-                '{}/security/checks/auto-accept?{}/'.format(
+                '{}/security/checks/auto-accept/?{}'.format(
                     settings.API_URL,
                     urlencode((
                         ('prisoner_profile_id', self.SENDER_CHECK['credit']['prisoner_profile']),
@@ -5004,7 +5009,7 @@ class CheckAssignViewTestCase(BaseCheckViewTestCase, SecurityViewTestCase):
             )
             rsps.add(
                 rsps.GET,
-                '{}/security/checks/auto-accept?{}/'.format(
+                '{}/security/checks/auto-accept/?{}'.format(
                     settings.API_URL,
                     urlencode((
                         ('prisoner_profile_id', self.SENDER_CHECK['credit']['prisoner_profile']),
@@ -5097,7 +5102,7 @@ class CheckAssignViewTestCase(BaseCheckViewTestCase, SecurityViewTestCase):
             )
             rsps.add(
                 rsps.GET,
-                '{}/security/checks/auto-accept?{}/'.format(
+                '{}/security/checks/auto-accept/?{}'.format(
                     settings.API_URL,
                     urlencode((
                         ('prisoner_profile_id', self.SENDER_CHECK['credit']['prisoner_profile']),
@@ -5184,7 +5189,7 @@ class CheckAssignViewTestCase(BaseCheckViewTestCase, SecurityViewTestCase):
             )
             rsps.add(
                 rsps.GET,
-                '{}/security/checks/auto-accept?{}/'.format(
+                '{}/security/checks/auto-accept/?{}'.format(
                     settings.API_URL,
                     urlencode((
                         ('prisoner_profile_id', self.SENDER_CHECK['credit']['prisoner_profile']),
@@ -5308,7 +5313,7 @@ class CheckAssignViewTestCase(BaseCheckViewTestCase, SecurityViewTestCase):
             )
             rsps.add(
                 rsps.GET,
-                '{}/security/checks/auto-accept?{}/'.format(
+                '{}/security/checks/auto-accept/?{}'.format(
                     settings.API_URL,
                     urlencode((
                         ('prisoner_profile_id', self.SENDER_CHECK['credit']['prisoner_profile']),

--- a/mtp_noms_ops/apps/security/tests/test_views.py
+++ b/mtp_noms_ops/apps/security/tests/test_views.py
@@ -32,7 +32,11 @@ from security import (
     required_permissions,
     provided_job_info_flag,
 )
-from security.constants import CHECK_REJECTION_CATEGORY_TEXT_MAPPING, CHECK_REJECTION_CATEGORY_BOOLEAN_MAPPING
+from security.constants import (
+    CHECK_REJECTION_CATEGORY_TEXT_MAPPING,
+    CHECK_REJECTION_CATEGORY_BOOLEAN_MAPPING,
+    CHECK_AUTO_ACCEPT_UNIQUE_CONSTRAINT_ERROR
+)
 from security.forms.object_list import PrisonSelectorSearchFormMixin, PRISON_SELECTOR_USER_PRISONS_CHOICE_VALUE
 from security.models import EmailNotifications
 from security.tests import api_url, TEST_IMAGE_DATA
@@ -4015,7 +4019,7 @@ class AcceptOrRejectCheckViewTestCase(BaseCheckViewTestCase, SecurityViewTestCas
                 status=400,
                 json={
                     'non_field_errors': [
-                        'The fields debit_card_sender_details, prisoner_profile must make a unique set.'
+                        CHECK_AUTO_ACCEPT_UNIQUE_CONSTRAINT_ERROR
                     ]
                 }
             )

--- a/mtp_noms_ops/apps/security/utils.py
+++ b/mtp_noms_ops/apps/security/utils.py
@@ -1,5 +1,6 @@
 import collections
 import datetime
+import logging
 import re
 
 from django.utils import timezone
@@ -9,6 +10,8 @@ from mtp_common.auth import USER_DATA_SESSION_KEY
 from mtp_common.auth.api_client import get_api_session
 
 from security import hmpps_employee_flag, confirmed_prisons_flag, provided_job_info_flag
+
+logger = logging.getLogger('mtp')
 
 
 def get_need_attention_date():
@@ -57,8 +60,8 @@ def convert_date_fields(object_list, include_nested=False):
                         new_value = timezone.localtime(new_value)
                     obj[field] = new_value
                     break
-                except (ValueError, TypeError):
-                    pass
+                except (ValueError, TypeError) as e:
+                    logger.warning(e)
         return obj
 
     if isinstance(object_list, dict):

--- a/mtp_noms_ops/apps/security/views/check.py
+++ b/mtp_noms_ops/apps/security/views/check.py
@@ -185,10 +185,16 @@ class AcceptOrRejectCheckView(FormView):
 
     def form_valid(self, form):
         if self.request.method == 'POST':
-            result = form.accept_or_reject()
+            result, additional_info_message = form.accept_or_reject()
 
             if not result:
                 return self.form_invalid(form)
+            if additional_info_message:
+                messages.add_message(
+                    self.request,
+                    messages.INFO,
+                    gettext_lazy(additional_info_message),
+                )
 
             if form.data['fiu_action'] == 'accept':
                 ui_message = gettext_lazy('Credit accepted')

--- a/mtp_noms_ops/apps/security/views/check.py
+++ b/mtp_noms_ops/apps/security/views/check.py
@@ -145,7 +145,7 @@ class AcceptOrRejectCheckView(FormView):
             payload['results']
         ))
         if len(existing_auto_accept_rules) == 1:
-            return self.get_latest_auto_accept_state(existing_auto_accept_rules[0])
+            return convert_date_fields(self.get_latest_auto_accept_state(existing_auto_accept_rules[0]))
 
     def get_context_data(self, **kwargs):
         context_data = super().get_context_data(**kwargs)

--- a/mtp_noms_ops/apps/security/views/check.py
+++ b/mtp_noms_ops/apps/security/views/check.py
@@ -1,3 +1,5 @@
+from urllib.parse import urlencode
+
 from django.contrib import messages
 from django.http import Http404, HttpResponseRedirect
 from django.urls import reverse, reverse_lazy
@@ -113,6 +115,34 @@ class AcceptOrRejectCheckView(FormView):
         )
         return form_kwargs
 
+    @staticmethod
+    def is_latest_state_active(auto_accept_rule):
+        return sorted(
+            auto_accept_rule['states'], key=lambda x: x['created']
+        )[-1]['active']
+
+    def is_existing_active_auto_accept_rule(self, api_session, debit_card_sender_details_id, prisoner_profile_id):
+        query_existing_auto_accept_rule = api_session.get(
+            '/security/checks/auto-accept?{}'.format(
+                urlencode((
+                    ('prisoner_profile_id', prisoner_profile_id),
+                    ('debit_card_sender_details_id', debit_card_sender_details_id)
+                ))
+            )
+        )
+
+        payload = query_existing_auto_accept_rule.json()
+        #  unfortunately django-filters OR's filters rather than ANDing them
+        existing_auto_accept_rules = filter(
+            lambda x: (
+                x['prisoner_profile'] == prisoner_profile_id
+                and x['debit_card_sender_details'] == debit_card_sender_details_id
+                and self.is_latest_state_active(x)
+            ),
+            payload['results']
+        )
+        return len(list(existing_auto_accept_rules)) > 0
+
     def get_context_data(self, **kwargs):
         context_data = super().get_context_data(**kwargs)
 
@@ -121,6 +151,13 @@ class AcceptOrRejectCheckView(FormView):
             raise Http404('Credit to check not found')
 
         api_session = context_data['form'].session
+        context_data['can_create_auto_accept'] = not self.is_existing_active_auto_accept_rule(
+            api_session,
+            detail_object['credit']['billing_address'][
+                'debit_card_sender_details'
+            ],
+            detail_object['credit']['prisoner_profile'],
+        )
 
         # keep query string in breadcrumbs
         list_url = self.request.build_absolute_uri(str(self.list_url))

--- a/mtp_noms_ops/assets-src/stylesheets/views/_checks.scss
+++ b/mtp_noms_ops/assets-src/stylesheets/views/_checks.scss
@@ -206,3 +206,7 @@ table.mtp-table--review {
 .mtp-check-accept-container {
   display: inline-block;
 }
+
+.mtp-font-weight-bold {
+  font-weight: bold;
+}

--- a/mtp_noms_ops/assets-src/stylesheets/views/_checks.scss
+++ b/mtp_noms_ops/assets-src/stylesheets/views/_checks.scss
@@ -202,3 +202,7 @@ table.mtp-table--review {
 .mtp-check-details-spacing {
   margin-top: 1em;
 }
+
+.mtp-check-accept-container {
+  display: inline-block;
+}

--- a/mtp_noms_ops/templates/security/accept_or_reject_check.html
+++ b/mtp_noms_ops/templates/security/accept_or_reject_check.html
@@ -194,7 +194,7 @@
                 <span class="mtp-font-weight-bold">Started by:</span>
                 {{ unbound_active_auto_accept_state.added_by.first_name}} {{ unbound_active_auto_accept_state.added_by.last_name}}
                 <br/>
-                <span class="mtp-font-weight-bold">Date:</span>{{ unbound_active_auto_accept_state.created |date:'SHORT_DATETIME_FORMAT' }}<br/>
+                <span class="mtp-font-weight-bold">Date:</span> {{ unbound_active_auto_accept_state.created |date:'SHORT_DATETIME_FORMAT' }}<br/>
                 <span class="mtp-font-weight-bold">Reason for automatically accepting:</span>
                 {{ unbound_active_auto_accept_state.reason }}
               </p>

--- a/mtp_noms_ops/templates/security/accept_or_reject_check.html
+++ b/mtp_noms_ops/templates/security/accept_or_reject_check.html
@@ -186,11 +186,17 @@
           {% include 'mtp_common/forms/textarea.html' with field=form.accept_further_details input_classes='form-control-3-4' %}
           <div class="mtp-check-accept-container">
             {% if unbound_active_auto_accept_state %}
-              <p>
-                {% blocktrans trimmed with sender_name=check.credit.sender_name prisoner_number=check.credit.prisoner_number added_by_fn=unbound_active_auto_accept_state.added_by.first_name added_by_ln=unbound_active_auto_accept_state.added_by.last_name reason=unbound_active_auto_accept_state.reason %}
-                  This check is associated with an active auto-rule between {{ sender_name }} and {{ prisoner_number }}
-                  This rule was activated by {{ added_by_fn }} {{ added_by_ln }}. The reason given was {{ reason }}
+              <p class="panel panel-border-wide">
+                {% blocktrans trimmed with sender_name=check.credit.sender_name prisoner_number=check.credit.prisoner_number %}
+                  Auto accept started for credits from {{sender_name}} to {{prisoner_number}}
                 {% endblocktrans %}
+                </br>
+                <span class="mtp-font-weight-bold">Started by:</span>
+                {{ unbound_active_auto_accept_state.added_by.first_name}} {{ unbound_active_auto_accept_state.added_by.last_name}}
+                <br/>
+                <span class="mtp-font-weight-bold">Date:</span>{{ unbound_active_auto_accept_state.created |date:'SHORT_DATETIME_FORMAT' }}<br/>
+                <span class="mtp-font-weight-bold">Reason for automatically accepting:</span>
+                {{ unbound_active_auto_accept_state.reason }}
               </p>
             {% else %}
               <div class="multiple-choice form-group" data-target="auto_accept_reason">

--- a/mtp_noms_ops/templates/security/accept_or_reject_check.html
+++ b/mtp_noms_ops/templates/security/accept_or_reject_check.html
@@ -183,8 +183,8 @@
         <div class="form-group">
           <h2 class="heading-medium">{% trans 'Accept or reject this credit' %}</h2>
           <h3 class="heading-medium">{% trans 'To accept this credit:' %}</h3>
-          <div>
-            {% include 'mtp_common/forms/textarea.html' with field=form.accept_further_details input_classes='form-control-3-4' %}
+          {% include 'mtp_common/forms/textarea.html' with field=form.accept_further_details input_classes='form-control-3-4' %}
+          <div class="mtp-check-accept-container">
             <div class="multiple-choice form-group" data-target="auto_accept_reason">
               <input id="example-auto_accept_reason" class="js-ToggleTextFieldOnChange" type="checkbox" name="checkbox-rejection-group" value="No">
               <label for="example-auto_accept_reason">
@@ -199,6 +199,7 @@
               <label class="form-label" for="rejection-auto_accept_reason">{% trans 'Give reason for automatically accepting' %}</label>
               <input class="form-control" name="auto_accept_reason" type="text" id="rejection-auto_accept_reason" disabled>
             </div>
+            <br/>
             <button type="submit" class="button" name="fiu_action" value="accept">
               {% trans 'Accept credit' %}
             </button>

--- a/mtp_noms_ops/templates/security/accept_or_reject_check.html
+++ b/mtp_noms_ops/templates/security/accept_or_reject_check.html
@@ -185,7 +185,15 @@
           <h3 class="heading-medium">{% trans 'To accept this credit:' %}</h3>
           {% include 'mtp_common/forms/textarea.html' with field=form.accept_further_details input_classes='form-control-3-4' %}
           <div class="mtp-check-accept-container">
-            {% if can_create_auto_accept %}
+            {% if unbound_active_auto_accept_state %}
+              <p>
+                {% comment %} TODO check that the user object is serialized in this context{% endcomment %}
+                {% blocktrans trimmed with sender_name=check.credit.sender_name prisoner_number=check.credit.prisoner_number added_by_fn=unbound_active_auto_accept_state.added_by.first_name added_by_ln=unbound_active_auto_accept_state.added_by.last_name reason=unbound_active_auto_accept_state.reason %}
+                  This check is associated with an active auto-rule between {{ sender_name }} and {{ prisoner_number }}
+                  This rule was activated by {{ added_by_fn }} {{ added_by_ln }}. The reason given was {{ reason }}
+                {% endblocktrans %}
+              </p>
+            {% else %}
               <div class="multiple-choice form-group" data-target="auto_accept_reason">
                 <input id="example-auto_accept_reason" class="js-ToggleTextFieldOnChange" type="checkbox" name="checkbox-rejection-group" value="No">
                 <label for="example-auto_accept_reason">
@@ -260,10 +268,20 @@
         </p>
         <p>
           <strong>{% trans 'Decision details' %}:</strong>
+          {% for reason, value in check.rejection_reasons.items %}
+            {{ reason | get_human_readable_check_field }}{% if value != True %}: {{ value }}{% endif %}
+            <br/>
+          {% endfor %}
           {% if check.decision_reason %}
-            {{ check.decision_reason }}
-          {% else %}
+            Further Details: {{ check.decision_reason }}
+          {% elif not check.rejection_reasons %}
             {% trans 'No decision reason entered' %}
+          {% endif %}
+          {% if check.auto_accept_rule_state.active %}
+            {% blocktrans trimmed with sender_name=check.credit.sender_name prisoner_number=check.credit.prisoner_number added_by_fn=check.auto_accept_rule_state.added_by.first_name added_by_ln=check.auto_accept_rule_state.added_by.last_name reason=check.auto_accept_rule_state.reason %}
+              This check is associated with an active auto-rule between {{ sender_name }} and {{ prisoner_number }}
+              This rule was activated by {{ added_by_fn }} {{ added_by_ln }}. The reason given was {{ reason }}
+            {% endblocktrans %}
           {% endif %}
         </p>
 

--- a/mtp_noms_ops/templates/security/accept_or_reject_check.html
+++ b/mtp_noms_ops/templates/security/accept_or_reject_check.html
@@ -187,7 +187,6 @@
           <div class="mtp-check-accept-container">
             {% if unbound_active_auto_accept_state %}
               <p>
-                {% comment %} TODO check that the user object is serialized in this context{% endcomment %}
                 {% blocktrans trimmed with sender_name=check.credit.sender_name prisoner_number=check.credit.prisoner_number added_by_fn=unbound_active_auto_accept_state.added_by.first_name added_by_ln=unbound_active_auto_accept_state.added_by.last_name reason=unbound_active_auto_accept_state.reason %}
                   This check is associated with an active auto-rule between {{ sender_name }} and {{ prisoner_number }}
                   This rule was activated by {{ added_by_fn }} {{ added_by_ln }}. The reason given was {{ reason }}
@@ -276,12 +275,6 @@
             Further Details: {{ check.decision_reason }}
           {% elif not check.rejection_reasons %}
             {% trans 'No decision reason entered' %}
-          {% endif %}
-          {% if check.auto_accept_rule_state.active %}
-            {% blocktrans trimmed with sender_name=check.credit.sender_name prisoner_number=check.credit.prisoner_number added_by_fn=check.auto_accept_rule_state.added_by.first_name added_by_ln=check.auto_accept_rule_state.added_by.last_name reason=check.auto_accept_rule_state.reason %}
-              This check is associated with an active auto-rule between {{ sender_name }} and {{ prisoner_number }}
-              This rule was activated by {{ added_by_fn }} {{ added_by_ln }}. The reason given was {{ reason }}
-            {% endblocktrans %}
           {% endif %}
         </p>
 

--- a/mtp_noms_ops/templates/security/accept_or_reject_check.html
+++ b/mtp_noms_ops/templates/security/accept_or_reject_check.html
@@ -182,9 +182,23 @@
 
         <div class="form-group">
           <h2 class="heading-medium">{% trans 'Accept or reject this credit' %}</h2>
-          <h3 class="heading-medium">{% trans 'To accept this credit:' %}</h2>
+          <h3 class="heading-medium">{% trans 'To accept this credit:' %}</h3>
           <div>
             {% include 'mtp_common/forms/textarea.html' with field=form.accept_further_details input_classes='form-control-3-4' %}
+            <div class="multiple-choice form-group" data-target="auto_accept_reason">
+              <input id="example-auto_accept_reason" class="js-ToggleTextFieldOnChange" type="checkbox" name="checkbox-rejection-group" value="No">
+              <label for="example-auto_accept_reason">
+                {% blocktrans trimmed with sender_name=check.credit.sender_name prisoner_number=check.credit.prisoner_number %}
+                  Automatically accept future credits from {{ sender_name }} to {{ prisoner_number }}
+                {% endblocktrans %}
+                <br/>
+                {% trans 'They will be flagged in Decision history.' %}
+              </label>
+            </div>
+            <div class="panel panel-border-narrow js-hidden" id="auto_accept_reason">
+              <label class="form-label" for="rejection-auto_accept_reason">{% trans 'Give reason for automatically accepting' %}</label>
+              <input class="form-control" name="auto_accept_reason" type="text" id="rejection-auto_accept_reason" disabled>
+            </div>
             <button type="submit" class="button" name="fiu_action" value="accept">
               {% trans 'Accept credit' %}
             </button>

--- a/mtp_noms_ops/templates/security/accept_or_reject_check.html
+++ b/mtp_noms_ops/templates/security/accept_or_reject_check.html
@@ -185,20 +185,22 @@
           <h3 class="heading-medium">{% trans 'To accept this credit:' %}</h3>
           {% include 'mtp_common/forms/textarea.html' with field=form.accept_further_details input_classes='form-control-3-4' %}
           <div class="mtp-check-accept-container">
-            <div class="multiple-choice form-group" data-target="auto_accept_reason">
-              <input id="example-auto_accept_reason" class="js-ToggleTextFieldOnChange" type="checkbox" name="checkbox-rejection-group" value="No">
-              <label for="example-auto_accept_reason">
-                {% blocktrans trimmed with sender_name=check.credit.sender_name prisoner_number=check.credit.prisoner_number %}
-                  Automatically accept future credits from {{ sender_name }} to {{ prisoner_number }}
-                {% endblocktrans %}
-                <br/>
-                {% trans 'They will be flagged in Decision history.' %}
-              </label>
-            </div>
-            <div class="panel panel-border-narrow js-hidden" id="auto_accept_reason">
-              <label class="form-label" for="rejection-auto_accept_reason">{% trans 'Give reason for automatically accepting' %}</label>
-              <input class="form-control" name="auto_accept_reason" type="text" id="rejection-auto_accept_reason" disabled>
-            </div>
+            {% if can_create_auto_accept %}
+              <div class="multiple-choice form-group" data-target="auto_accept_reason">
+                <input id="example-auto_accept_reason" class="js-ToggleTextFieldOnChange" type="checkbox" name="checkbox-rejection-group" value="No">
+                <label for="example-auto_accept_reason">
+                  {% blocktrans trimmed with sender_name=check.credit.sender_name prisoner_number=check.credit.prisoner_number %}
+                    Automatically accept future credits from {{ sender_name }} to {{ prisoner_number }}
+                  {% endblocktrans %}
+                  <br/>
+                  {% trans 'They will be flagged in Decision history.' %}
+                </label>
+              </div>
+              <div class="panel panel-border-narrow js-hidden" id="auto_accept_reason">
+                <label class="form-label" for="rejection-auto_accept_reason">{% trans 'Give reason for automatically accepting' %}</label>
+                <input class="form-control" name="auto_accept_reason" type="text" id="rejection-auto_accept_reason" disabled>
+              </div>
+            {% endif %}
             <br/>
             <button type="submit" class="button" name="fiu_action" value="accept">
               {% trans 'Accept credit' %}

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -8,3 +8,5 @@ watchdog>=0.9.0,<1
 parameterized==0.7.4
 pdbpp
 django-pdb
+django-pudb3
+pudb


### PR DESCRIPTION
Ticket link: https://dsdmoj.atlassian.net/browse/MTP-1738
Relies on: https://github.com/ministryofjustice/money-to-prisoners-api/pull/626/
To discuss:
* https://dsdmoj.atlassian.net/browse/MTP-1738?focusedCommentId=132135
* What to do on auto-accept POST/PATCH failure. Do we revert the state of the check, otherwise they won't be able to make another attempt at creating an auto-accept rule

TODO:
* [x] Fix case where auto-accept rule is added for same debit-card prisoner-combos more than once without reloading the page (reload check before accepting?)
* [x] Figure out why `api_session` taken from form in `get_context_data` doesn't have valid auth credentials bound