### PR TITLE
MTP-1537: Remove dependencies in mtp-common (11.1.0)

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -2,14 +2,4 @@
 
 money-to-prisoners-common~=11.1.0
 
-Django>=2.2,<2.3
-requests>=2.22,<3
-django-widget-tweaks>=1.4,<1.5
-transifex-client>=0.12
-django-anymail[mailgun]~=7.2
 openpyxl>=2.5,<2.6
-uWSGI==2.0.19.1
-
-django-form-error-reporting>=0.9
-django-moj-irat>=0.6
-django-zendesk-tickets>=0.14


### PR DESCRIPTION
Bump `mtp-common` to `11.1.0` and remove dependencies which are already
requested there. This reduce duplication and reduce the risk of clashes
between packages versions.


Ticket: https://dsdmoj.atlassian.net/browse/MTP-1537