### PR TITLE
Remove banners announcing November 2020 policy changes

### DIFF
--- a/mtp_noms_ops/apps/security/views/dashboard.py
+++ b/mtp_noms_ops/apps/security/views/dashboard.py
@@ -17,7 +17,6 @@ class DashboardView(TemplateView):
             'link_cards': self.get_link_cards(),
             'saved_search_cards': self.get_saved_search_cards(),
             'admin_cards': self.get_admin_cards(),
-            'november_second_changes_live': settings.NOVEMBER_SECOND_CHANGES_LIVE,
         })
         return super().get_context_data(**kwargs)
 

--- a/mtp_noms_ops/apps/security/views/object_list.py
+++ b/mtp_noms_ops/apps/security/views/object_list.py
@@ -1,5 +1,4 @@
 from django.urls import reverse
-from django.conf import settings
 from django.utils.translation import gettext_lazy as _
 
 from security.forms.object_list import (
@@ -59,7 +58,6 @@ class CreditListViewV2(SecuritySearchViewV2):
     object_list_context_key = 'credits'
     object_name = _('credit')
     object_name_plural = _('credits')
-    november_second_changes_live = settings.NOVEMBER_SECOND_CHANGES_LIVE
 
 
 class DisbursementListViewV2(SecuritySearchViewV2):
@@ -76,7 +74,6 @@ class DisbursementListViewV2(SecuritySearchViewV2):
     object_list_context_key = 'disbursements'
     object_name = _('disbursement')
     object_name_plural = _('disbursements')
-    november_second_changes_live = settings.NOVEMBER_SECOND_CHANGES_LIVE
 
 
 class SenderListViewV2(SecuritySearchViewV2):

--- a/mtp_noms_ops/templates/dashboard.html
+++ b/mtp_noms_ops/templates/dashboard.html
@@ -12,31 +12,6 @@
 {% block content %}
   {% notification_banners request 'noms_ops_security_dashboard' %}
 
-  {% if request.can_access_security %}
-    {% if november_second_changes_live %}
-      {% captureoutput as banner_heading %}
-        <a href="{% url 'security:policy_change' %}">
-          {% trans 'Check you’re up to date with recent policy changes' %}
-        </a>
-      {% endcaptureoutput %}
-      {% include 'mtp_common/components/notification-banner.html' with banner_level='info' banner_title='info'|notification_level banner_heading=banner_heading only %}
-    {% else %}
-      {% captureoutput as banner_message %}{% spaceless %}
-        <h3><strong>{% trans 'Credits' %}</strong></h3>
-        <p>{% trans 'Senders will no longer be able to send money by bank transfer or pre-paid card.' %}</p>
-
-        <h3><strong>{% trans 'Disbursements' %}</strong></h3>
-        <p>{% trans 'Prisoners can send out a maximum of £50 a week to up to 5 different people.' %}</p>
-
-        <p><a href="{% url 'security:policy_change' %}">{% trans 'More details about Credit and Disbursement changes' %}</a></p>
-
-        <h3><strong>{% trans 'Prisoner accounts' %}</strong></h3>
-        <p>{% trans 'Credits will not be accepted into a prisoner’s account if it holds £900 or more.' %}</p>
-      {% endspaceless %}{% endcaptureoutput %}
-      {% include 'mtp_common/components/notification-banner.html' with banner_level='info' banner_title='info'|notification_level banner_heading=_('What the Nov 2nd policy changes mean') banner_message=banner_message only %}
-    {% endif %}
-  {% endif %}
-
   <header>
     <h1 class="govuk-heading-xl">
       {% blocktrans trimmed with full_name=request.user.get_full_name|default:request.user.username %}

--- a/mtp_noms_ops/templates/security/credits_list.html
+++ b/mtp_noms_ops/templates/security/credits_list.html
@@ -5,17 +5,6 @@
 
 {% block content %}
 
-  {% if not view.november_second_changes_live %}
-    {% if not is_search_results %}
-      {% captureoutput as banner_heading %}
-        <a href="{% url 'security:policy_change' %}">
-          {% trans 'No more bank transfers' %}
-        </a>
-      {% endcaptureoutput %}
-      {% include 'mtp_common/components/notification-banner.html' with banner_level='info' banner_title='info'|notification_level banner_heading=banner_heading only %}
-    {% endif %}
-  {% endif %}
-
   <form id="simple-search-{{ view.object_name_plural|slugify }}" class="mtp-security-search mtp-form-analytics" method="get">
 
     <div class="govuk-grid-row">

--- a/mtp_noms_ops/templates/security/disbursements_list.html
+++ b/mtp_noms_ops/templates/security/disbursements_list.html
@@ -5,17 +5,6 @@
 
 {% block content %}
 
-  {% if not view.november_second_changes_live %}
-    {% if not is_search_results %}
-      {% captureoutput as banner_heading %}
-        <a href="{% url 'security:policy_change' %}">
-          {% trans 'How the cap on disbursements works' %}
-        </a>
-      {% endcaptureoutput %}
-      {% include 'mtp_common/components/notification-banner.html' with banner_level='info' banner_title='info'|notification_level banner_heading=banner_heading only %}
-    {% endif %}
-  {% endif %}
-
   <form id="simple-search-{{ view.object_name_plural|slugify }}" class="mtp-security-search mtp-form-analytics" method="get">
 
     <div class="govuk-grid-row">


### PR DESCRIPTION
… as it's been 4 months so all users will have seen them. We don't want to distract people from other, more important, messages that we may wish to show instead.
The page they linked to remains in case it's been linked to and in case we may want to refer users in future.

[MTP-1808](https://dsdmoj.atlassian.net/browse/MTP-1808)