### PR TITLE
Fix dashboard display of saved searches

### DIFF
--- a/mtp_noms_ops/apps/security/views/dashboard.py
+++ b/mtp_noms_ops/apps/security/views/dashboard.py
@@ -65,7 +65,7 @@ class DashboardView(TemplateView):
                 'link': search['site_url'],
                 'description': (
                     ngettext('%d new credit', '%d new credits', search['new_result_count']) % search['new_result_count']
-                    if search['new_result_count']
+                    if search.get('new_result_count')
                     else ''
                 )
             }


### PR DESCRIPTION
…for users whose monitored list is too long so the `new_result_count` values are not populated. this key was previously only used in the template so was ignored if it was missing.