### PR TITLE
MTP-1837: FAQ (when signed out)

### DIFF
--- a/mtp_noms_ops/apps/views.py
+++ b/mtp_noms_ops/apps/views.py
@@ -1,0 +1,21 @@
+from django.conf import settings
+from django.urls import reverse_lazy
+from django.utils.translation import gettext_lazy as _
+from django.views.generic import TemplateView
+
+
+class FAQView(TemplateView):
+    template_name = 'faq.html'
+    title = _('What do you need help with?')
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+
+        context['breadcrumbs_back'] = reverse_lazy('login')
+        context['cashbook_url'] = settings.CASHBOOK_URL
+        context['reset_password_url'] = reverse_lazy('reset_password')
+        # TODO: Stop-gap solution: Replace with sign-up URL once functionality is there
+        # context['sign_up_url'] = reverse_lazy('sign-up')
+        context['sign_up_url'] = reverse_lazy('submit_ticket') + '?message=I%20want%20to%20request%20an%20account.%20%5BPlease%20provide%20your%20name%2C%20email%20address%20and%20Quantum%20ID%5D'  # noqa: E501
+
+        return context

--- a/mtp_noms_ops/templates/faq.html
+++ b/mtp_noms_ops/templates/faq.html
@@ -1,0 +1,88 @@
+{% extends 'base.html' %}
+{% load i18n %}
+
+{% block page_title %}{{ view.title }} – {{ block.super }}{% endblock %}
+
+
+{% block content %}
+  {{ block.super }}
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+
+      <header>
+        <h1 class="govuk-heading-xl">{{ view.title }}</h1>
+      </header>
+
+
+      <h2 class="govuk-heading-m" id="faq-locked-out">
+        {% trans "I’m locked out" %}
+      </h2>
+
+      <p>
+        {% blocktrans trimmed %}
+          If you mis-type your password too many times, you'll be locked out.
+        {% endblocktrans %}
+        {% blocktrans trimmed %}
+          Try again in about half an hour.
+        {% endblocktrans %}
+      </p>
+
+
+      <h2 class="govuk-heading-m" id="faq-may-have-account">
+        {% trans "I may already have an account" %}
+      </h2>
+
+      <p>
+        {% blocktrans trimmed %}
+          Try <a href="{{ reset_password_url }}">resetting your password</a>.
+        {% endblocktrans %}
+        {% blocktrans trimmed %}
+          If you have an account, you'll get an email with a link. If not, <a href="{{ sign_up_url }}">request an account</a>.
+        {% endblocktrans %}
+      </p>
+
+
+      <h2 class="govuk-heading-m" id="faq-username">
+        {% trans "I've forgotten or need to change my username" %}
+      </h2>
+
+      <p>
+        {% url 'submit_ticket' as contact_us_url %}
+        {% blocktrans trimmed %}
+            To change your username, <a href="{{ contact_us_url }}?message=My%20new%20username%20%28usually%20your%20Quantum%20ID%29%20is%20%5Bplease%20fill%20in%5D">contact us</a>.
+        {% endblocktrans %}
+      </p>
+
+
+      <h2 class="govuk-heading-m" id="faq-reset-password">
+        {% trans "Reset password isn’t working" %}
+      </h2>
+
+      <p>
+        {% url 'submit_ticket' as contact_us_url %}
+        {% blocktrans trimmed %}
+          To reset your password, <a href="{{ contact_us_url }}?message=I%20need%20help%20resetting%20my%20password.%20My%20username%20is%20%5Bplease%20fill%20in%5D.">contact us</a>.
+        {% endblocktrans %}
+      </p>
+
+
+      <h2 class="govuk-heading-m" id="faq-cashbook-account">
+        {% trans "I want a digital cashbook account to process money in and out of prison" %}
+      </h2>
+
+      <p>
+        {% blocktrans trimmed %}
+          You can only have one account - intelligence tool OR digital cashbook.
+        {% endblocktrans %}
+        <br />
+        {% blocktrans trimmed %}
+          If you need a cashbook account, instead of an intelligence tool one, go directly to the <a href="{{ cashbook_url }}">digital cashbook</a> and request it.
+        {% endblocktrans %}
+      </p>
+
+
+    </div>
+  </div>
+
+{% endblock %}

--- a/mtp_noms_ops/templates/govuk-frontend/components/footer.html
+++ b/mtp_noms_ops/templates/govuk-frontend/components/footer.html
@@ -8,7 +8,7 @@
   </h2>
   <ul class="govuk-footer__inline-list">
     <li class="govuk-footer__inline-list-item">
-      <a class="govuk-footer__link" href="{% url 'submit_ticket' %}">
+      <a class="govuk-footer__link" href="{% url 'faq' %}">
         {% trans 'Help and feedback' %}
       </a>
     </li>

--- a/mtp_noms_ops/templates/mtp_auth/login.html
+++ b/mtp_noms_ops/templates/mtp_auth/login.html
@@ -50,7 +50,7 @@
           {% trans 'Your head of security can set up an account for you if you don’t have access already.' %}
         </p>
         <p>
-          <a href="{% url 'submit_ticket' %}">
+          <a href="{% url 'faq' %}">
             {% trans 'Need more help?' %}
           </a>
         </p>

--- a/mtp_noms_ops/urls.py
+++ b/mtp_noms_ops/urls.py
@@ -15,6 +15,8 @@ from mtp_common.auth import views as auth_views
 from mtp_common.auth.exceptions import Unauthorized
 from mtp_common.metrics.views import metrics_view
 
+from views import FAQView
+
 
 def login_view(request):
     return auth_views.login(request, template_name='mtp_auth/login.html', extra_context={
@@ -37,6 +39,8 @@ urlpatterns = i18n_patterns(
     url(r'^$', root_view, name='root'),
     url(r'^prisoner-location/', include('prisoner_location_admin.urls')),
     url(r'^settings/', include('settings.urls')),
+
+    url(r'^faq/', FAQView.as_view(), name='faq'),
     url(r'^feedback/', include('feedback.urls')),
 
     url(r'^login/$', login_view, name='login'),


### PR DESCRIPTION
When user is not signed in, the links to "Get help" no longer take them
to the "Submit feedback" page but instead they take them to an FAQ page
with questions related to login problems etc.

This FAQ page still has links to contact us.

⚠️ **NOTE**: Currently the 'Request an account' functionality is not present in `noms-ops` (see ['Request an account - intel tool' epic](https://dsdmoj.atlassian.net/browse/MTP-1812)). 
So in the interest of making this releasable the question with the link to 'request an account' take the user to the 'Submit a ticket' page with a pre-populated message.


Ticket: https://dsdmoj.atlassian.net/browse/MTP-1837