### PR TITLE
'Get help' link in footer change when user logs in

### DIFF
--- a/mtp_noms_ops/templates/govuk-frontend/components/footer.html
+++ b/mtp_noms_ops/templates/govuk-frontend/components/footer.html
@@ -8,7 +8,12 @@
   </h2>
   <ul class="govuk-footer__inline-list">
     <li class="govuk-footer__inline-list-item">
-      <a class="govuk-footer__link" href="{% url 'faq' %}">
+      {% if request.user.is_authenticated %}
+        {% url 'submit_ticket' as get_help_url %}
+      {% else %}
+        {% url 'faq' as get_help_url %}
+      {% endif %}
+      <a class="govuk-footer__link" href="{{ get_help_url }}">
         {% trans 'Help and feedback' %}
       </a>
     </li>


### PR DESCRIPTION
This was going to the signed out FAQ which is wrong.