### PR TITLE
Simplify 'Contact us' form

### DIFF
--- a/mtp_noms_ops/apps/feedback/forms.py
+++ b/mtp_noms_ops/apps/feedback/forms.py
@@ -1,0 +1,15 @@
+from django.utils.translation import gettext_lazy as _
+from django import forms
+from zendesk_tickets.forms import EmailTicketForm
+
+
+class ContactUsForm(EmailTicketForm):
+    ticket_content = forms.CharField(
+        label=_('Please give details'),
+        widget=forms.Textarea,
+    )
+
+    contact_email = forms.EmailField(
+        label=_('Your email address'),
+        required=True,
+    )

--- a/mtp_noms_ops/apps/feedback/urls.py
+++ b/mtp_noms_ops/apps/feedback/urls.py
@@ -7,6 +7,8 @@ from mtp_common.views import (
     GetHelpSuccessView as BaseGetHelpSuccessView,
 )
 
+from .forms import ContactUsForm
+
 
 class FeedbackContextMixin:
     """
@@ -14,11 +16,12 @@ class FeedbackContextMixin:
     """
 
     def get_context_data(self, **kwargs):
-        kwargs['get_help_title'] = gettext('Get help and leave feedback')
+        kwargs['get_help_title'] = gettext('Contact us')
         return super(FeedbackContextMixin, self).get_context_data(**kwargs)
 
 
 class GetHelpView(FeedbackContextMixin, BaseGetHelpView):
+    form_class = ContactUsForm
     success_url = reverse_lazy('feedback_success')
     ticket_subject = 'MTP for digital team - Prisoner Money Intelligence'
     ticket_tags = ['feedback', 'mtp', 'noms-ops', settings.ENVIRONMENT]

--- a/mtp_noms_ops/templates/mtp_common/feedback/submit_feedback.html
+++ b/mtp_noms_ops/templates/mtp_common/feedback/submit_feedback.html
@@ -1,0 +1,7 @@
+{% extends 'mtp_common/feedback/submit_feedback.html' %}
+{% load i18n %}
+
+
+{% block get_help_leading %}
+  {# This removes the lead paragraph above textarea #}
+{% endblock %}


### PR DESCRIPTION
As per prototype (https://pm-intelligence-tool.herokuapp.com/help/contact_us):
- Remove lead paragraph
- Changed textarea label to 'Please give details'
- Changed page title to 'Contact us' (like per prototype)

Also:
- Made 'Your email address' field mandatory.

Ticket: https://dsdmoj.atlassian.net/browse/MTP-1848