### PR TITLE
MTP-1813: Request an intel tool account

### DIFF
--- a/mtp_noms_ops/apps/mtp_auth/forms.py
+++ b/mtp_noms_ops/apps/mtp_auth/forms.py
@@ -48,8 +48,6 @@ class SignUpForm(BaseSignUpForm, BaseTicketForm):
             self.add_error(None, _('This service is currently unavailable'))
 
     def clean(self):
-        self.cleaned_data['role'] = 'security'
-
         if self.is_valid() and self.user_already_requested_account():
             return self.submit_ticket(
                 self.request,

--- a/mtp_noms_ops/apps/mtp_auth/forms.py
+++ b/mtp_noms_ops/apps/mtp_auth/forms.py
@@ -48,9 +48,6 @@ class SignUpForm(BaseSignUpForm, BaseTicketForm):
         self.cleaned_data['role'] = 'security'
 
         if self.is_valid() and self.user_already_requested_account():
-            # Subsequent account requests sent to ZenDesk are approved by Family Services
-            self.request.session['approver'] = _('Family Services')
-
             return self.submit_ticket(
                 self.request,
                 subject=self.account_request_zendesk_subject,

--- a/mtp_noms_ops/apps/mtp_auth/forms.py
+++ b/mtp_noms_ops/apps/mtp_auth/forms.py
@@ -23,8 +23,11 @@ class AcceptRequestForm(AcceptRequestFormBase):
 
 
 class SignUpForm(BaseSignUpForm, BaseTicketForm):
-
-    account_request_zendesk_subject = _('MTP for digital team - Prisoner money intelligence - Request for new staff account')  # noqa: E501
+    account_request_zendesk_subject = (
+        'MTP for digital team - '
+        'Prisoner money intelligence - '
+        'Request for new staff account'
+    )
     zendesk_tags = ('feedback', 'mtp', 'noms-ops', 'account_request', settings.ENVIRONMENT)
 
     role = forms.CharField(label=_('Role'), initial='security')

--- a/mtp_noms_ops/apps/mtp_auth/forms.py
+++ b/mtp_noms_ops/apps/mtp_auth/forms.py
@@ -1,6 +1,18 @@
+import logging
+
 from django import forms
-from django.utils.translation import gettext_lazy as _
-from mtp_common.user_admin.forms import AcceptRequestForm as AcceptRequestFormBase
+from django.conf import settings
+from django.utils.translation import gettext as _
+from mtp_common.user_admin.forms import (
+    AcceptRequestForm as AcceptRequestFormBase,
+    SignUpForm as BaseSignUpForm,
+)
+from oauthlib.oauth2 import OAuth2Error
+from requests import RequestException
+from zendesk_tickets.forms import BaseTicketForm
+
+
+logger = logging.getLogger('mtp')
 
 
 class AcceptRequestForm(AcceptRequestFormBase):
@@ -8,3 +20,43 @@ class AcceptRequestForm(AcceptRequestFormBase):
         label=_('This account is for an FIU user (FIU users will be able to manage other user accounts)'),
         required=False,
     )
+
+
+class SignUpForm(BaseSignUpForm, BaseTicketForm):
+
+    account_request_zendesk_subject = _('MTP for digital team - Prisoner money intelligence - Request for new staff account')
+    zendesk_tags = ('feedback', 'mtp', 'noms-ops', 'account_request', settings.ENVIRONMENT)
+
+    role = forms.CharField(label=_('Role'), initial='security')
+    manager_email = forms.EmailField(label=_("Your manager's email"))
+
+    def user_already_requested_account(self):
+        try:
+            response = self.api_session.get(
+                'requests/',
+                params={
+                    'username': self.cleaned_data['username'],
+                    'role__name': self.cleaned_data['role'],
+                },
+            )
+            return response.json().get('count', 0) > 0
+        except (RequestException, OAuth2Error, ValueError):
+            logger.exception('Could not look up access requests')
+            self.add_error(None, _('This service is currently unavailable'))
+
+    def clean(self):
+        self.cleaned_data['role'] = 'security'
+
+        if self.is_valid() and self.user_already_requested_account():
+            # Subsequent account requests sent to ZenDesk are approved by Family Services
+            self.request.session['approver'] = _('Family Services')
+
+            return self.submit_ticket(
+                self.request,
+                subject=self.account_request_zendesk_subject,
+                tags=self.zendesk_tags,
+                ticket_template_name='mtp_common/user_admin/new-account-request-ticket.txt',
+                requester_email=self.cleaned_data['email'],
+            )
+
+        return super().clean()

--- a/mtp_noms_ops/apps/mtp_auth/forms.py
+++ b/mtp_noms_ops/apps/mtp_auth/forms.py
@@ -2,7 +2,7 @@ import logging
 
 from django import forms
 from django.conf import settings
-from django.utils.translation import gettext as _
+from django.utils.translation import gettext_lazy as _
 from mtp_common.user_admin.forms import (
     AcceptRequestForm as AcceptRequestFormBase,
     SignUpForm as BaseSignUpForm,

--- a/mtp_noms_ops/apps/mtp_auth/forms.py
+++ b/mtp_noms_ops/apps/mtp_auth/forms.py
@@ -24,7 +24,7 @@ class AcceptRequestForm(AcceptRequestFormBase):
 
 class SignUpForm(BaseSignUpForm, BaseTicketForm):
 
-    account_request_zendesk_subject = _('MTP for digital team - Prisoner money intelligence - Request for new staff account')
+    account_request_zendesk_subject = _('MTP for digital team - Prisoner money intelligence - Request for new staff account')  # noqa: E501
     zendesk_tags = ('feedback', 'mtp', 'noms-ops', 'account_request', settings.ENVIRONMENT)
 
     role = forms.CharField(label=_('Role'), initial='security')

--- a/mtp_noms_ops/apps/mtp_auth/tests/test_views.py
+++ b/mtp_noms_ops/apps/mtp_auth/tests/test_views.py
@@ -50,7 +50,6 @@ class RequestAccessTestCase(SimpleTestCase):
             self.assertIn('role=security', rsps.calls[1].request.body)
 
         self.assertContains(response, 'Your request for access has been sent')
-        self.assertContains(response, 'a member of the Financial Investigations Unit')
 
     def test_request_account_already_requested(self):
         with responses.RequestsMock() as rsps:
@@ -112,7 +111,6 @@ class RequestAccessTestCase(SimpleTestCase):
             )
 
         self.assertContains(response, 'Your request for access has been sent')
-        self.assertContains(response, 'Family Services')
 
     def test_api_response_error(self):
         with responses.RequestsMock() as rsps, silence_logger():

--- a/mtp_noms_ops/apps/mtp_auth/tests/test_views.py
+++ b/mtp_noms_ops/apps/mtp_auth/tests/test_views.py
@@ -1,0 +1,129 @@
+import json
+
+from django.conf import settings
+from django.test import override_settings, SimpleTestCase
+from django.urls import reverse
+from mtp_common.test_utils import silence_logger
+import responses
+
+
+ZENDESK_BASE_URL = 'https://zendesk.mtp.local'
+
+
+@override_settings(
+    ZENDESK_BASE_URL=ZENDESK_BASE_URL,
+)
+class RequestAccessTestCase(SimpleTestCase):
+
+    def setUp(self):
+        self.account_request_valid_payload = {
+            'first_name': 'My First Name',
+            'last_name': 'My Last Name',
+            'email': 'my-username@mtp.local',
+            'username': 'my-username',
+            'role': 'security',
+            'manager_email': 'my-manager@mtp.local',
+            'reason': 'because I need an account',
+        }
+
+    def test_request_account_first_request(self):
+        with responses.RequestsMock() as rsps:
+            rsps.add(
+                rsps.GET,
+                f'{settings.API_URL}/requests/?username=my-username&role__name=security',
+                json={'count': 0},
+                status=200,
+            )
+            rsps.add(
+                rsps.POST,
+                f'{settings.API_URL}/requests/',
+                json={},
+                status=201,
+            )
+
+            response = self.client.post(
+                reverse('sign-up'),
+                data=self.account_request_valid_payload,
+            )
+
+            self.assertEqual(len(rsps.calls), 2)
+            self.assertIn('role=security', rsps.calls[1].request.body)
+
+        self.assertContains(response, 'Your request for access has been sent')
+        self.assertContains(response, 'a member of the Financial Investigations Unit')
+
+    def test_request_account_already_requested(self):
+        with responses.RequestsMock() as rsps:
+            rsps.add(
+                rsps.GET,
+                f'{settings.API_URL}/requests/?username=my-username&role__name=security',
+                json={'count': 1},
+                status=200,
+            )
+            rsps.add(
+                rsps.POST,
+                f'{ZENDESK_BASE_URL}/api/v2/tickets.json',
+            )
+
+            response = self.client.post(
+                reverse('sign-up'),
+                data=self.account_request_valid_payload,
+            )
+
+            zendesk_request = rsps.calls[1].request
+            zendesk_request_payload = json.loads(zendesk_request.body)
+
+            self.maxDiff = None
+            self.assertDictEqual(
+                zendesk_request_payload,
+                {
+                    'ticket': {
+                        'comment': {
+                            'body': (
+                                'Requesting a new staff account - Prisoner money intelligence\n'
+                                '============================================================\n'
+                                '\n'
+                                'Reason for requesting account: because I need an account'
+                                '\n'
+                                '\n'
+                                '---\n'
+                                '\n'
+                                'Forename: My First Name\n'
+                                'Surname: My Last Name\n'
+                                'Username (Quantum ID): my-username\n'
+                                'Staff email: my-username@mtp.local\n'
+                                'Account Type: security\n'
+                                'Manager email: my-manager@mtp.local'
+                            )
+                        },
+                        'custom_fields': [
+                            {'id': 26047167, 'value': ''},
+                            {'id': 29241738, 'value': 'my-username'},
+                        ],
+                        'group_id': 26417927,
+                        'requester': {
+                            'email': 'my-username@mtp.local',
+                            'name': 'Sender: my-username',
+                        },
+                        'subject': 'MTP for digital team - Prisoner money intelligence - Request for new staff account',
+                        'tags': ['feedback', 'mtp', 'noms-ops', 'account_request', settings.ENVIRONMENT],
+                    },
+                },
+            )
+
+        self.assertContains(response, 'Your request for access has been sent')
+        self.assertContains(response, 'Family Services')
+
+    def test_api_response_error(self):
+        with responses.RequestsMock() as rsps, silence_logger():
+            rsps.add(
+                rsps.GET,
+                f'{settings.API_URL}/requests/?username=my-username&role__name=security',
+                status=500,
+            )
+            response = self.client.post(
+                reverse('sign-up'),
+                data=self.account_request_valid_payload,
+            )
+
+        self.assertContains(response, 'This service is currently unavailable')

--- a/mtp_noms_ops/apps/mtp_auth/urls.py
+++ b/mtp_noms_ops/apps/mtp_auth/urls.py
@@ -1,0 +1,8 @@
+from django.conf.urls import url
+
+from .views import SignUpView
+
+
+urlpatterns = [
+    url(r'^sign-up/$', SignUpView.as_view(), name='sign-up'),
+]

--- a/mtp_noms_ops/apps/mtp_auth/views.py
+++ b/mtp_noms_ops/apps/mtp_auth/views.py
@@ -16,12 +16,6 @@ class SignUpView(BaseSignUpView):
     form_class = SignUpForm
 
     def get_context_data(self, **kwargs):
-        approver = self.request.session.get(
-            'approver',
-            _('a member of the Financial Investigations Unit'),
-        )
-
         kwargs['breadcrumbs_back'] = reverse_lazy('root')
-        kwargs['approver'] = approver
 
         return super().get_context_data(**kwargs)

--- a/mtp_noms_ops/apps/mtp_auth/views.py
+++ b/mtp_noms_ops/apps/mtp_auth/views.py
@@ -1,7 +1,27 @@
-from mtp_common.user_admin.views import AcceptRequestView as AcceptRequestViewBase
+from django.urls import reverse_lazy
+from django.utils.translation import gettext_lazy as _
+from mtp_common.user_admin.views import (
+    SignUpView as BaseSignUpView,
+    AcceptRequestView as AcceptRequestViewBase,
+)
 
-from .forms import AcceptRequestForm
+from .forms import AcceptRequestForm, SignUpForm
 
 
 class AcceptRequestView(AcceptRequestViewBase):
     form_class = AcceptRequestForm
+
+
+class SignUpView(BaseSignUpView):
+    form_class = SignUpForm
+
+    def get_context_data(self, **kwargs):
+        approver = self.request.session.get(
+            'approver',
+            _('a member of the Financial Investigations Unit'),
+        )
+
+        kwargs['breadcrumbs_back'] = reverse_lazy('root')
+        kwargs['approver'] = approver
+
+        return super().get_context_data(**kwargs)

--- a/mtp_noms_ops/apps/mtp_auth/views.py
+++ b/mtp_noms_ops/apps/mtp_auth/views.py
@@ -1,8 +1,7 @@
 from django.urls import reverse_lazy
-from django.utils.translation import gettext_lazy as _
 from mtp_common.user_admin.views import (
-    SignUpView as BaseSignUpView,
     AcceptRequestView as AcceptRequestViewBase,
+    SignUpView as BaseSignUpView,
 )
 
 from .forms import AcceptRequestForm, SignUpForm

--- a/mtp_noms_ops/apps/settings/tests/test_views.py
+++ b/mtp_noms_ops/apps/settings/tests/test_views.py
@@ -69,6 +69,13 @@ class ConfirmPrisonTestCase(SecurityBaseTestCase):
 
     @responses.activate
     def test_does_not_redirect_for_user_admin(self):
+        responses.add(
+            responses.GET,
+            api_url('/requests') + '?page_size=1',
+            json={'count': 0},
+            status=200,
+        )
+
         self.login(
             responses,
             user_data=self.get_user_data(

--- a/mtp_noms_ops/apps/views.py
+++ b/mtp_noms_ops/apps/views.py
@@ -14,8 +14,6 @@ class FAQView(TemplateView):
         context['breadcrumbs_back'] = reverse_lazy('login')
         context['cashbook_url'] = settings.CASHBOOK_URL
         context['reset_password_url'] = reverse_lazy('reset_password')
-        # TODO: Stop-gap solution: Replace with sign-up URL once functionality is there
-        # context['sign_up_url'] = reverse_lazy('sign-up')
-        context['sign_up_url'] = reverse_lazy('submit_ticket') + '?message=I%20want%20to%20request%20an%20account.%20%5BPlease%20provide%20your%20name%2C%20email%20address%20and%20Quantum%20ID%5D'  # noqa: E501
+        context['sign_up_url'] = reverse_lazy('sign-up')
 
         return context

--- a/mtp_noms_ops/settings/base.py
+++ b/mtp_noms_ops/settings/base.py
@@ -56,6 +56,7 @@ INSTALLED_APPS = (
 )
 PROJECT_APPS = (
     'anymail',
+    'mtp_auth',
     'mtp_common',
     'mtp_common.metrics',
     'widget_tweaks',

--- a/mtp_noms_ops/templates/mtp_auth/login.html
+++ b/mtp_noms_ops/templates/mtp_auth/login.html
@@ -45,22 +45,19 @@
 
     <div class="govuk-grid-row">
       <section class="govuk-grid-column-one-half">
-        <h2 class="govuk-heading-m">{% trans 'How to get access' %}</h2>
+        <h2 class="govuk-heading-m">{% trans 'Request an account' %}</h2>
         <p>
-          {% trans 'Your head of security can set up an account for you if you don’t have access already.' %}
+          {% trans 'If you work in intelligence in a public or private prison in England or Wales, you can request an intelligence tool account.' %}
         </p>
+
         <p>
-          <a href="{% url 'faq' %}">
-            {% trans 'Need more help?' %}
+          <a href="{% url 'sign-up' %}">
+            {% trans 'Request an account' %}
           </a>
         </p>
 
-        <h2 class="govuk-heading-m">{% trans 'New disbursement tool' %}</h2>
         <p>
-          {% trans 'We’ve launched a new digital disbursement tool which tracks money sent out of prisons.' %}
-        </p>
-        <p>
-          {% trans 'All public UK prisons now have access.' %}
+          <a href="{% url 'faq' %}">{% trans 'Get help' %}</a> if you're having difficulties getting an account or signing in.
         </p>
       </section>
 

--- a/mtp_noms_ops/templates/mtp_common/user_admin/new-account-request-ticket.txt
+++ b/mtp_noms_ops/templates/mtp_common/user_admin/new-account-request-ticket.txt
@@ -1,0 +1,13 @@
+Requesting a new staff account - Prisoner money intelligence
+============================================================
+
+Reason for requesting account: {{ reason|safe }}
+
+---
+
+Forename: {{ first_name|safe }}
+Surname: {{ last_name|safe }}
+Username (Quantum ID): {{ username|safe }}
+Staff email: {{ email|safe }}
+Account Type: {{ role|safe }}
+Manager email: {{ manager_email|safe }}

--- a/mtp_noms_ops/templates/mtp_common/user_admin/sign-up-success.html
+++ b/mtp_noms_ops/templates/mtp_common/user_admin/sign-up-success.html
@@ -1,0 +1,11 @@
+{% extends 'mtp_common/user_admin/sign-up-success.html' %}
+{% load i18n %}
+{% load mtp_common %}
+
+{% block whats_next_message %}
+  <p>
+    {% blocktrans trimmed with approver=approver|wrapwithtag:'strong' %}
+      Once {{ approver }} has approved your request, you’ll get an email with your sign in details.
+    {% endblocktrans %}
+  </p>
+{% endblock %}

--- a/mtp_noms_ops/templates/mtp_common/user_admin/sign-up-success.html
+++ b/mtp_noms_ops/templates/mtp_common/user_admin/sign-up-success.html
@@ -5,7 +5,7 @@
 {% block whats_next_message %}
   <p>
     {% blocktrans trimmed with approver=approver|wrapwithtag:'strong' %}
-      Once {{ approver }} has approved your request, you’ll get an email with your sign in details.
+      Once <strong>a member of the Financial Investigations Unit</strong> has approved your request, you’ll get an email with your sign in details.
     {% endblocktrans %}
   </p>
 {% endblock %}

--- a/mtp_noms_ops/templates/mtp_common/user_admin/sign-up-success.html
+++ b/mtp_noms_ops/templates/mtp_common/user_admin/sign-up-success.html
@@ -4,7 +4,7 @@
 
 {% block whats_next_message %}
   <p>
-    {% blocktrans trimmed with approver=approver|wrapwithtag:'strong' %}
+    {% blocktrans trimmed %}
       Once <strong>a member of the Financial Investigations Unit</strong> has approved your request, you’ll get an email with your sign in details.
     {% endblocktrans %}
   </p>

--- a/mtp_noms_ops/templates/mtp_common/user_admin/sign-up.html
+++ b/mtp_noms_ops/templates/mtp_common/user_admin/sign-up.html
@@ -4,5 +4,5 @@
 
 
 {% block sign_up_extras_fields %}
-  {% include 'mtp_common/forms/field.html' with field=form.manager_email rows=1 input_classes="govuk-input--width-10" only %}
+  {% include 'mtp_common/forms/field.html' with field=form.manager_email input_classes="govuk-input--width-10" only %}
 {% endblock %}

--- a/mtp_noms_ops/templates/mtp_common/user_admin/sign-up.html
+++ b/mtp_noms_ops/templates/mtp_common/user_admin/sign-up.html
@@ -1,3 +1,8 @@
 {% extends 'mtp_common/user_admin/sign-up.html' %}
 
 {% block body_classes %}{{ block.super }} mtp-page-with-staff-email-input{% endblock %}
+
+
+{% block sign_up_extras_fields %}
+  {% include 'mtp_common/forms/field.html' with field=form.manager_email rows=1 input_classes="govuk-input--width-10" only %}
+{% endblock %}

--- a/mtp_noms_ops/urls.py
+++ b/mtp_noms_ops/urls.py
@@ -45,6 +45,8 @@ urlpatterns = i18n_patterns(
     url(r'^faq/', FAQView.as_view(), name='faq'),
     url(r'^feedback/', include('feedback.urls')),
 
+    url(r'^', include('mtp_auth.urls')),
+
     url(r'^login/$', login_view, name='login'),
     url(
         r'^logout/$', auth_views.logout, {


### PR DESCRIPTION
### What
Users can request an account directly. 

It uses [existing 'Account Request' functionality in `api`](https://github.com/ministryofjustice/money-to-prisoners-api/blob/8f7882917a5ccce1d0bd7a7a529e9bab523590de/mtp_api/apps/mtp_auth/urls.py#L11) with some tweaks.

⚠️ **NOTE**: As prison is optional for these account requests and as a new "Your manager's email" field needs to be added, this PR is [dependent on the corresponding `api` PR](https://github.com/ministryofjustice/money-to-prisoners-api/pull/649) to be merged.


### Links
Ticket: https://dsdmoj.atlassian.net/browse/MTP-1813
Prototype starts: https://pm-intelligence-tool.herokuapp.com/sign-in