### PR TITLE
Include trailing slash in auto-accept rule detail url

### DIFF
--- a/mtp_noms_ops/apps/security/urls.py
+++ b/mtp_noms_ops/apps/security/urls.py
@@ -369,7 +369,7 @@ urlpatterns = [
         name='auto_accept_rule_list',
     ),
     url(
-        r'^security/checks/auto-accept-rules/(?P<auto_accept_rule_id>\d+)$',
+        r'^security/checks/auto-accept-rules/(?P<auto_accept_rule_id>\d+)/$',
         fiu_security_test(views.AutoAcceptRuleDetailView.as_view()),
         name='auto_accept_rule_detail',
     ),


### PR DESCRIPTION
…to match all other url formats