### PR TITLE
Prevent repetition of labels when displaying only "further details" on actioned credits

### DIFF
--- a/mtp_noms_ops/templates/security/accept_or_reject_check.html
+++ b/mtp_noms_ops/templates/security/accept_or_reject_check.html
@@ -164,7 +164,10 @@
                   <br/>
                 {% endfor %}
                 {% if credit.security_check.decision_reason %}
-                <strong>{% trans 'Further Details:' %}</strong> {{ credit.security_check.decision_reason }}
+                  {% if credit.security_check.rejection_reasons %}
+                    {% trans 'Further details' %}:
+                  {% endif %}
+                  {{ credit.security_check.decision_reason }}
                 {% elif not credit.security_check.rejection_reasons %}
                   {% trans 'No decision reason entered' %}
                 {% endif %}

--- a/mtp_noms_ops/templates/security/credits_history_list.html
+++ b/mtp_noms_ops/templates/security/credits_history_list.html
@@ -89,7 +89,10 @@
                 <br/>
               {% endfor %}
               {% if check.decision_reason %}
-                Further Details: {{ check.decision_reason }}
+                {% if check.rejection_reasons %}
+                  {% trans 'Further details' %}:
+                {% endif %}
+                {{ check.decision_reason }}
               {% elif not check.rejection_reasons %}
                 {% trans 'No decision reason entered' %}
               {% endif %}


### PR DESCRIPTION
If a credit was accepted or rejected only with "further details", 2 labels were displayed. Now, the "further details" label is displayed only if the credit was rejected and other reasons had been given as well.