### PR TITLE
Move security check rejection reasons to mtp-common

### DIFF
--- a/mtp_noms_ops/apps/security/constants.py
+++ b/mtp_noms_ops/apps/security/constants.py
@@ -1,34 +1,5 @@
-from django.utils.translation import gettext_lazy as _
-
-
-CHECK_REJECTION_CATEGORY_TEXT_MAPPING = {
-    'fiu_investigation_id': _('Associated FIU investigation'),
-    'intelligence_report_id': _('Associated intelligence report (IR)'),
-    'other_reason': _('Other reason'),
-}
-CHECK_REJECTION_CATEGORY_BOOLEAN_MAPPING = {
-    'payment_source_paying_multiple_prisoners': _('Payment source is paying multiple prisoners'),
-    'payment_source_multiple_cards': _('Payment source is using multiple cards'),
-    'payment_source_linked_other_prisoners': _('Payment source is linked to other prisoner/s'),
-    'payment_source_known_email': _('Payment source is using a known email'),
-    'payment_source_unidentified': _('Payment source is unidentified'),
-    'prisoner_multiple_payments_payment_sources': _('Prisoner has multiple payments or payment sources')
-}
-
-CHECK_DETAIL_RENDERED_MAPPING = dict(
-    tuple(CHECK_REJECTION_CATEGORY_TEXT_MAPPING.items()) + tuple(CHECK_REJECTION_CATEGORY_BOOLEAN_MAPPING.items())
-)
-
-CHECK_DETAIL_FORM_MAPPING = {
-    'decision_reason': _('Give further details (optional)'),
-    'auto_accept_reason': _('Give reason for automatically accepting'),
-    'rejection_reasons': dict(
-        tuple(CHECK_REJECTION_CATEGORY_TEXT_MAPPING.items()) + tuple(CHECK_REJECTION_CATEGORY_BOOLEAN_MAPPING.items())
-    )
-}
+SECURITY_FORMS_DEFAULT_PAGE_SIZE = 20
 
 # This is as custom-defined exception within the API service that we match against
 CHECK_AUTO_ACCEPT_UNIQUE_CONSTRAINT_ERROR = \
     'An existing AutoAcceptRule is present for this DebitCardSenderDetails/PrisonerProfile pair'
-
-SECURITY_FORMS_DEFAULT_PAGE_SIZE = 20

--- a/mtp_noms_ops/apps/security/forms/object_list.py
+++ b/mtp_noms_ops/apps/security/forms/object_list.py
@@ -9,6 +9,7 @@ from django.utils.dateparse import parse_date
 from django.utils.translation import gettext_lazy as _
 from mtp_common.forms.fields import SplitDateField
 
+from security.constants import SECURITY_FORMS_DEFAULT_PAGE_SIZE
 from security.forms.object_base import (
     AmountPattern,
     parse_amount,
@@ -881,7 +882,7 @@ class NotificationsForm(SecurityForm):
     unfiltered_description_template = 'All notifications are shown below.'
     description_templates = ()
 
-    page_size = 25
+    page_size = SECURITY_FORMS_DEFAULT_PAGE_SIZE
 
     def __init__(self, request, **kwargs):
         super().__init__(request, **kwargs)

--- a/mtp_noms_ops/apps/security/templatetags/security.py
+++ b/mtp_noms_ops/apps/security/templatetags/security.py
@@ -253,7 +253,10 @@ def format_security_check_rejection_reasons(check):
     return format_html_join(
         mark_safe('<br />\n'),
         '{}',
-        map(lambda description: [description], human_readable_check_rejection_reasons(check['rejection_reasons']))
+        (
+            (description,)
+            for description in human_readable_check_rejection_reasons(check['rejection_reasons'])
+        )
     )
 
 

--- a/mtp_noms_ops/apps/security/tests/test_views.py
+++ b/mtp_noms_ops/apps/security/tests/test_views.py
@@ -22,6 +22,7 @@ from django.utils.timezone import make_aware
 from mtp_common.auth import USER_DATA_SESSION_KEY, urljoin
 from mtp_common.auth.api_client import get_request_token_url
 from mtp_common.auth.test_utils import generate_tokens
+from mtp_common.security.checks import CHECK_REJECTION_TEXT_CATEGORY_LABELS, CHECK_REJECTION_BOOL_CATEGORY_LABELS
 from mtp_common.test_utils import silence_logger
 from openpyxl import load_workbook
 from parameterized import parameterized
@@ -35,12 +36,7 @@ from security import (
     required_permissions,
     provided_job_info_flag,
 )
-from security.constants import (
-    CHECK_REJECTION_CATEGORY_TEXT_MAPPING,
-    CHECK_REJECTION_CATEGORY_BOOLEAN_MAPPING,
-    CHECK_AUTO_ACCEPT_UNIQUE_CONSTRAINT_ERROR,
-    SECURITY_FORMS_DEFAULT_PAGE_SIZE
-)
+from security.constants import SECURITY_FORMS_DEFAULT_PAGE_SIZE, CHECK_AUTO_ACCEPT_UNIQUE_CONSTRAINT_ERROR
 from security.forms.object_list import PrisonSelectorSearchFormMixin, PRISON_SELECTOR_USER_PRISONS_CHOICE_VALUE
 from security.models import EmailNotifications
 from security.tests import api_url, TEST_IMAGE_DATA
@@ -120,15 +116,15 @@ def offset_isodatetime_by_ten_seconds(isodatetime, offset_multiplier=1):
 
 def generate_rejection_category_test_cases_text():
     return [
-        (text_category, f'i_am_a_{text_category}_value')
-        for text_category in CHECK_REJECTION_CATEGORY_TEXT_MAPPING.keys()
+        (text_category, f'User-entered {text_category} text')
+        for text_category in CHECK_REJECTION_TEXT_CATEGORY_LABELS
     ]
 
 
 def generate_rejection_category_test_cases_bool():
     return [
         (text_category, True)
-        for text_category in CHECK_REJECTION_CATEGORY_BOOLEAN_MAPPING.keys()
+        for text_category in CHECK_REJECTION_BOOL_CATEGORY_LABELS
     ]
 
 
@@ -3210,7 +3206,7 @@ class CreditsHistoryListViewTestCase(BaseCheckViewTestCase):
             self.assertContains(response, 'No decision reason entered')
 
     @parameterized.expand(
-        CHECK_REJECTION_CATEGORY_BOOLEAN_MAPPING.items()
+        CHECK_REJECTION_BOOL_CATEGORY_LABELS.items()
     )
     def test_credit_history_row_has_reason_checkbox_populated(
         self, rejection_reason_key, rejection_reason_full
@@ -4093,7 +4089,7 @@ class AcceptOrRejectCheckViewTestCase(BaseCheckViewTestCase, SecurityViewTestCas
         )
 
     @parameterized.expand(
-        CHECK_REJECTION_CATEGORY_BOOLEAN_MAPPING.items()
+        CHECK_REJECTION_BOOL_CATEGORY_LABELS.items()
     )
     def test_credit_history_row_has_reason_checkbox_populated_for_prisoner_check(
         self, rejection_reason_key, rejection_reason_full
@@ -4189,7 +4185,7 @@ class AcceptOrRejectCheckViewTestCase(BaseCheckViewTestCase, SecurityViewTestCas
             self.assertContains(response, rejection_reason_full)
 
     @parameterized.expand(
-        CHECK_REJECTION_CATEGORY_BOOLEAN_MAPPING.items()
+        CHECK_REJECTION_BOOL_CATEGORY_LABELS.items()
     )
     def test_credit_history_row_has_reason_checkbox_populated_for_sender_check(
         self, rejection_reason_key, rejection_reason_full

--- a/mtp_noms_ops/apps/security/tests/test_views.py
+++ b/mtp_noms_ops/apps/security/tests/test_views.py
@@ -2301,7 +2301,7 @@ class NotificationsTestCase(SecurityBaseTestCase):
             self.login(rsps)
             rsps.add(
                 rsps.GET,
-                api_url('/events/pages/') + '?rule=MONP&rule=MONS&offset=0&limit=25',
+                api_url('/events/pages/') + f'?rule=MONP&rule=MONS&offset=0&limit={SECURITY_FORMS_DEFAULT_PAGE_SIZE}',
                 json={'count': 0, 'newest': None, 'oldest': None},
                 match_querystring=True
             )
@@ -2329,7 +2329,7 @@ class NotificationsTestCase(SecurityBaseTestCase):
             self.login(rsps)
             rsps.add(
                 rsps.GET,
-                api_url('/events/pages/') + '?rule=MONP&rule=MONS&offset=0&limit=25',
+                api_url('/events/pages/') + f'?rule=MONP&rule=MONS&offset=0&limit={SECURITY_FORMS_DEFAULT_PAGE_SIZE}',
                 json={'count': 0, 'newest': None, 'oldest': None},
                 match_querystring=True
             )
@@ -2357,7 +2357,7 @@ class NotificationsTestCase(SecurityBaseTestCase):
             self.login(rsps)
             rsps.add(
                 rsps.GET,
-                api_url('/events/pages/') + '?rule=MONP&rule=MONS&offset=0&limit=25',
+                api_url('/events/pages/') + f'?rule=MONP&rule=MONS&offset=0&limit={SECURITY_FORMS_DEFAULT_PAGE_SIZE}',
                 json={'count': 1, 'newest': '2019-07-15', 'oldest': '2019-07-15'},
                 match_querystring=True
             )
@@ -2403,7 +2403,7 @@ class NotificationsTestCase(SecurityBaseTestCase):
             self.login(rsps)
             rsps.add(
                 rsps.GET,
-                api_url('/events/pages/') + '?rule=MONP&rule=MONS&offset=0&limit=25',
+                api_url('/events/pages/') + f'?rule=MONP&rule=MONS&offset=0&limit={SECURITY_FORMS_DEFAULT_PAGE_SIZE}',
                 json={'count': 1, 'newest': '2019-07-15', 'oldest': '2019-07-15'},
                 match_querystring=True
             )
@@ -2444,7 +2444,7 @@ class NotificationsTestCase(SecurityBaseTestCase):
             self.login(rsps)
             rsps.add(
                 rsps.GET,
-                api_url('/events/pages/') + '?rule=MONP&rule=MONS&offset=0&limit=25',
+                api_url('/events/pages/') + f'?rule=MONP&rule=MONS&offset=0&limit={SECURITY_FORMS_DEFAULT_PAGE_SIZE}',
                 json={'count': 32, 'newest': '2019-07-15', 'oldest': '2019-06-21'},
                 match_querystring=True
             )
@@ -2491,7 +2491,7 @@ class NotificationsTestCase(SecurityBaseTestCase):
             self.login(rsps)
             rsps.add(
                 rsps.GET,
-                api_url('/events/pages/') + '?rule=MONP&rule=MONS&offset=0&limit=25',
+                api_url('/events/pages/') + f'?rule=MONP&rule=MONS&offset=0&limit={SECURITY_FORMS_DEFAULT_PAGE_SIZE}',
                 json={'count': 1, 'newest': '2019-07-15', 'oldest': '2019-07-15'},
                 match_querystring=True
             )

--- a/mtp_noms_ops/templates/security/accept_or_reject_check.html
+++ b/mtp_noms_ops/templates/security/accept_or_reject_check.html
@@ -159,10 +159,7 @@
                 <strong>{% trans 'Reason for automatically accepting' %}:</strong> {{ credit.security_check.auto_accept_rule_state.reason }}
               {% else %}
                 <strong>{% trans 'Decision details' %}:</strong>
-                {% for reason, value in credit.security_check.rejection_reasons.items %}
-                  {{ reason | get_human_readable_check_field }}{% if value != True %}: {{ value }}{% endif %}
-                  <br/>
-                {% endfor %}
+                {{ credit.security_check|format_security_check_rejection_reasons }}
                 {% if credit.security_check.decision_reason %}
                   {% if credit.security_check.rejection_reasons %}
                     {% trans 'Further details' %}:
@@ -273,10 +270,7 @@
         </p>
         <p>
           <strong>{% trans 'Decision details' %}:</strong>
-          {% for reason, value in check.rejection_reasons.items %}
-            {{ reason | get_human_readable_check_field }}{% if value != True %}: {{ value }}{% endif %}
-            <br/>
-          {% endfor %}
+          {{ check|format_security_check_rejection_reasons }}
           {% if check.decision_reason %}
             {% trans 'Further details' %}: {{ check.decision_reason }}
           {% elif not check.rejection_reasons %}

--- a/mtp_noms_ops/templates/security/credits_history_list.html
+++ b/mtp_noms_ops/templates/security/credits_history_list.html
@@ -84,10 +84,7 @@
               <strong>{% trans 'Reason for automatically accepting' %}:</strong> {{ check.auto_accept_rule_state.reason }}
             {% else %}
             <strong>{% trans 'Decision details' %}:</strong>
-              {% for reason, value in check.rejection_reasons.items %}
-                {{ reason | get_human_readable_check_field }}{% if value != True %}: {{ value }}{% endif %}
-                <br/>
-              {% endfor %}
+              {{ check|format_security_check_rejection_reasons }}
               {% if check.decision_reason %}
                 {% if check.rejection_reasons %}
                   {% trans 'Further details' %}:


### PR DESCRIPTION
So that the definitions/labels are shared amongst all MTP apps and therefore data from DB can be consistently understood throughout.


See related `mtp-common` PR: https://github.com/ministryofjustice/money-to-prisoners-common/pull/421