### PR TITLE
Allow setting domain names to which GOV.UK Notify will _not_ send emails [MTP-1901]

### DIFF
--- a/mtp_noms_ops/settings/base.py
+++ b/mtp_noms_ops/settings/base.py
@@ -265,6 +265,7 @@ MAX_CREDITS_TO_EMAIL = 20000
 GOVUK_NOTIFY_API_KEY = os.environ.get('GOVUK_NOTIFY_API_KEY', '')
 GOVUK_NOTIFY_REPLY_TO_PUBLIC = os.environ.get('GOVUK_NOTIFY_REPLY_TO_PUBLIC', '')
 GOVUK_NOTIFY_REPLY_TO_STAFF = os.environ.get('GOVUK_NOTIFY_REPLY_TO_STAFF', '')
+GOVUK_NOTIFY_BLOCKED_DOMAINS = set(os.environ.get('GOVUK_NOTIFY_BLOCKED_DOMAINS', '').split())
 # install GOV.UK Notify fallback for emails accidentally sent using Django's email functionality:
 EMAIL_BACKEND = 'mtp_common.notify.email_backend.NotifyEmailBackend'
 


### PR DESCRIPTION
… so that test site will not try to email fake addresses (thereby damaging reputation or raising errors)