### PR TITLE
Configure k8s api server url for CircleCI directly

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -95,7 +95,7 @@ jobs:
               echo "Deploying to test"
 
               echo -n ${K8S_CLUSTER_CERT} | base64 -d > /tmp/mtp-k8s-ca.crt
-              kubectl config set-cluster ${K8S_CLUSTER_NAME} --certificate-authority=/tmp/mtp-k8s-ca.crt --server=https://api.${K8S_CLUSTER_NAME}
+              kubectl config set-cluster ${K8S_CLUSTER_NAME} --certificate-authority=/tmp/mtp-k8s-ca.crt --server=${K8S_CLUSTER_SERVER}
               kubectl config set-credentials circleci --token=${K8S_TOKEN}
               kubectl config set-context ${K8S_CLUSTER_NAME} --cluster=${K8S_CLUSTER_NAME} --user=circleci --namespace=${K8S_NAMESPACE}
               kubectl config use-context ${K8S_CLUSTER_NAME}


### PR DESCRIPTION
… rather than deriving from cluster name (which no longer works in new EKS cluster).