### PR TITLE
Prevent double-submission of security-related forms

### DIFF
--- a/mtp_noms_ops/templates/security/accept_or_reject_check.html
+++ b/mtp_noms_ops/templates/security/accept_or_reject_check.html
@@ -21,9 +21,9 @@
         <form action="{% url 'security:assign_check' check_id=check.id %}" method="post">
           {% csrf_token %}
           {% if check.assigned_to %}
-            <button type="submit" name="assignment" class="govuk-button govuk-button--secondary" data-module="govuk-button" value="unassign">{% trans 'Remove from my list' %}</button>
+            <button type="submit" name="assignment" class="govuk-button govuk-button--secondary" data-module="govuk-button" data-prevent-double-click="true" value="unassign">{% trans 'Remove from my list' %}</button>
           {% else %}
-            <button type="submit" name="assignment" class="govuk-button govuk-button--secondary" data-module="govuk-button" value="assign">{% trans 'Add to my list' %}</button>
+            <button type="submit" name="assignment" class="govuk-button govuk-button--secondary" data-module="govuk-button" data-prevent-double-click="true" value="assign">{% trans 'Add to my list' %}</button>
           {% endif %}
         </form>
       {% endif %}
@@ -237,7 +237,7 @@
 
         {% endif %}
         <br/>
-        <button type="submit" class="govuk-button" data-module="govuk-button" name="fiu_action" value="accept">
+        <button type="submit" class="govuk-button" data-module="govuk-button" data-prevent-double-click="true" name="fiu_action" value="accept">
           {% trans 'Accept credit' %}
         </button>
 
@@ -270,7 +270,7 @@
 
         {% include 'mtp_common/forms/textarea.html' with field=form.reject_further_details rows=2 %}
 
-        <button type="submit" class="govuk-button govuk-button--warning" data-module="govuk-button" name="fiu_action" value="reject">
+        <button type="submit" class="govuk-button govuk-button--warning" data-module="govuk-button" data-prevent-double-click="true" name="fiu_action" value="reject">
           {% trans 'Reject credit' %}
         </button>
 

--- a/mtp_noms_ops/templates/security/auto_accept_rule.html
+++ b/mtp_noms_ops/templates/security/auto_accept_rule.html
@@ -73,7 +73,7 @@
             {% trans 'To stop auto accept:' %}
           </h2>
           {% include 'mtp_common/forms/textarea.html' with field=form.deactivation_reason %}
-          <button type="submit" class="govuk-button govuk-button--warning" data-module="govuk-button">
+          <button type="submit" class="govuk-button govuk-button--warning" data-module="govuk-button" data-prevent-double-click="true">
             {% trans 'Stop auto accept' %}
           </button>
         </form>

--- a/mtp_noms_ops/templates/security/base_advanced_search.html
+++ b/mtp_noms_ops/templates/security/base_advanced_search.html
@@ -23,7 +23,7 @@
 
         {% block advanced_search_fields %}{% endblock advanced_search_fields %}
 
-        <button type="submit" class="govuk-button" data-module="govuk-button" value="submit">{% blocktrans with object_name=view.object_name_plural %}Search {{ object_name }}{% endblocktrans %}</button>
+        <button type="submit" class="govuk-button" data-module="govuk-button" data-prevent-double-click="true" value="submit">{% blocktrans with object_name=view.object_name_plural %}Search {{ object_name }}{% endblocktrans %}</button>
       </div>
     </div>
 

--- a/mtp_noms_ops/templates/security/checks_list.html
+++ b/mtp_noms_ops/templates/security/checks_list.html
@@ -106,7 +106,7 @@
                   {% else %}
                     <form class="mtp-check-cell__list-form" action="{% url 'security:assign_check_then_list' check_id=check.id page=form.cleaned_data.page %}" method="post">
                       {% csrf_token %}
-                      <button type="submit" name="assignment" class="govuk-button govuk-button--secondary" data-module="govuk-button" value="assign">
+                      <button type="submit" name="assignment" class="govuk-button govuk-button--secondary" data-module="govuk-button" data-prevent-double-click="true" value="assign">
                         {% blocktrans trimmed with credit_to=check.credit.prisoner_name %}
                           Add <span class="govuk-visually-hidden">credit to {{credit_to}}</span> to my list
                         {% endblocktrans %}

--- a/mtp_noms_ops/templates/security/forms/top-area-object-list.html
+++ b/mtp_noms_ops/templates/security/forms/top-area-object-list.html
@@ -43,7 +43,7 @@
     {{ form.prison_selector.as_hidden }}
     {% include 'mtp_common/forms/field.html' with field=form.simple_search label_classes='govuk-!-font-size-27' only %}
     <div class="govuk-button-group">
-      <button type="submit" class="govuk-button" data-module="govuk-button" value="submit">{% blocktrans with object_name=view.object_name_plural %}Search {{ object_name }}{% endblocktrans %}</button>
+      <button type="submit" class="govuk-button" data-module="govuk-button" data-prevent-double-click="true" value="submit">{% blocktrans with object_name=view.object_name_plural %}Search {{ object_name }}{% endblocktrans %}</button>
       <a href="{{ advanced_search_url }}" class="govuk-link">
         {% trans 'Advanced search' %}
       </a>

--- a/mtp_noms_ops/templates/security/review.html
+++ b/mtp_noms_ops/templates/security/review.html
@@ -28,7 +28,7 @@
     {% csrf_token %}
 
     <div class="govuk-button-group govuk-!-display-none-print">
-      <button type="submit" name="submit" class="govuk-button" data-module="govuk-button" value="submit">{% trans 'Credits checked by security' %}</button>
+      <button type="submit" name="submit" class="govuk-button" data-module="govuk-button" data-prevent-double-click="true" value="submit">{% trans 'Credits checked by security' %}</button>
       <a class="mtp-print-trigger mtp-form-analytics__click govuk-link" href="#print-dialog" data-click-track="print-{{ view.get_class_name }},{{ view.get_used_request_params|join:'&' }}">{% trans 'Print these credits' %}</a>
     </div>
 
@@ -90,14 +90,14 @@
     </div>
 
     <p class="govuk-!-display-none-print">
-      <button type="submit" name="submit" class="govuk-button" data-module="govuk-button" value="submit">{% trans 'Credits checked by security' %}</button>
+      <button type="submit" name="submit" class="govuk-button" data-module="govuk-button" data-prevent-double-click="true" value="submit">{% trans 'Credits checked by security' %}</button>
     </p>
 
     {% dialoguebox html_id='confirm-checked' title=_('Have you checked these credits?') %}
       <p>{% trans 'These credits will be marked as checked in the digital cashbook.' %}</p>
       <p>{% trans 'You can view credits again in ‘Search all prison credits’.' %}</p>
       <br/>
-      <button type="submit" class="govuk-button govuk-!-margin-right-2" data-module="govuk-button" value="override">
+      <button type="submit" class="govuk-button govuk-!-margin-right-2" data-module="govuk-button" data-prevent-double-click="true" value="override">
         {% trans 'Yes, all credits checked' %}
       </button>
       <button type="button" class="govuk-button govuk-button--secondary {{ dialogue_close_class }}" data-module="govuk-button">


### PR DESCRIPTION
…because some requests take a very long time and users will be tempted to retry (thereby making it take even longer).