### PR TITLE
MTP-1937: Remove dependency on `django-form-error-reporting` mixins

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,5 @@ This is handled by [money-to-prisoners-deploy](https://github.com/ministryofjust
 
 There are several dependencies of the ``money-to-prisoners-noms-ops`` python library which are maintained by this team, so they may require code-changes when the dependencies (e.g. Django) of the ``money-to-prisoners-noms-ops`` python library are incremented.
 
-* django-form-error-reporting: https://github.com/ministryofjustice/django-form-error-reporting
 * django-zendesk-tickets: https://github.com/ministryofjustice/django-zendesk-tickets
 * django-moj-irat: https://github.com/ministryofjustice/django-moj-irat

--- a/mtp_noms_ops/apps/prisoner_location_admin/forms.py
+++ b/mtp_noms_ops/apps/prisoner_location_admin/forms.py
@@ -6,7 +6,6 @@ import re
 
 from django import forms
 from django.utils.translation import gettext_lazy as _
-from form_error_reporting import GARequestErrorReportingMixin
 from mtp_common.auth.api_client import get_api_session
 
 from prisoner_location_admin.tasks import update_locations
@@ -19,7 +18,7 @@ DOB_PATTERN = re.compile(
 DATE_FORMATS = ['%d/%m/%Y', '%d/%m/%y']
 
 
-class LocationFileUploadForm(GARequestErrorReportingMixin, forms.Form):
+class LocationFileUploadForm(forms.Form):
     location_file = forms.FileField(
         label=_('Location file'),
         error_messages={'required': _('Please choose a file')},

--- a/mtp_noms_ops/apps/security/forms/check.py
+++ b/mtp_noms_ops/apps/security/forms/check.py
@@ -4,7 +4,6 @@ from django import forms
 from django.contrib import messages
 from django.utils.functional import cached_property
 from django.utils.translation import gettext_lazy as _
-from form_error_reporting import GARequestErrorReportingMixin
 from mtp_common.auth.api_client import get_api_session
 from mtp_common.security.checks import (
     CHECK_REJECTION_TEXT_CATEGORY_LABELS,
@@ -180,7 +179,7 @@ class AutoAcceptListForm(SecurityForm):
         return object_list
 
 
-class AcceptOrRejectCheckForm(GARequestErrorReportingMixin, forms.Form):
+class AcceptOrRejectCheckForm(forms.Form):
     """
     CheckForm for accepting or rejecting a check.
     """
@@ -548,7 +547,7 @@ class AutoAcceptDetailForm(forms.Form):
         return True
 
 
-class AssignCheckToUserForm(GARequestErrorReportingMixin, forms.Form):
+class AssignCheckToUserForm(forms.Form):
     assignment = forms.ChoiceField(
         choices=[
             ('assign', _('Assign')),

--- a/mtp_noms_ops/apps/security/forms/eligibility.py
+++ b/mtp_noms_ops/apps/security/forms/eligibility.py
@@ -1,9 +1,8 @@
 from django import forms
 from django.utils.translation import gettext_lazy as _
-from form_error_reporting import GARequestErrorReportingMixin
 
 
-class HMPPSEmployeeForm(GARequestErrorReportingMixin, forms.Form):
+class HMPPSEmployeeForm(forms.Form):
     next = forms.CharField(required=False)
     confirmation = forms.ChoiceField(
         label=_('Are you a direct employee of HMPPS or a contracted prison and working in an intelligence function?'),

--- a/mtp_noms_ops/apps/security/forms/object_base.py
+++ b/mtp_noms_ops/apps/security/forms/object_base.py
@@ -13,7 +13,6 @@ from django.utils.dateformat import format as date_format
 from django.utils.functional import cached_property
 from django.utils.html import format_html, format_html_join
 from django.utils.translation import gettext_lazy as _, override as override_locale
-from form_error_reporting import GARequestErrorReportingMixin
 from mtp_common.api import retrieve_all_pages_for_path
 from mtp_common.auth.api_client import get_api_session
 from mtp_common.auth.exceptions import HttpNotFoundError
@@ -93,7 +92,7 @@ class AmountPattern(enum.Enum):
         ]
 
 
-class SecurityForm(GARequestErrorReportingMixin, forms.Form):
+class SecurityForm(forms.Form):
     """
     Base form for security searches, always uses initial values as defaults
     """

--- a/mtp_noms_ops/apps/security/forms/object_list.py
+++ b/mtp_noms_ops/apps/security/forms/object_list.py
@@ -37,10 +37,6 @@ class SearchFormV2Mixin(forms.Form):
     # indicates whether the form was used in advanced search
     advanced = forms.BooleanField(initial=False, required=False)
 
-    def get_ga_event_category(self):
-        """GA event category."""
-        return f'form-errors-{self.__class__.__name__}'
-
     def was_advanced_search_used(self):
         return self.cleaned_data.get('advanced', False)
 

--- a/mtp_noms_ops/apps/security/forms/review.py
+++ b/mtp_noms_ops/apps/security/forms/review.py
@@ -3,12 +3,11 @@ import datetime
 from django import forms
 from django.utils import timezone
 from django.utils.functional import cached_property
-from form_error_reporting import GARequestErrorReportingMixin
 from mtp_common.api import retrieve_all_pages_for_path
 from mtp_common.auth.api_client import get_api_session
 
 
-class ReviewCreditsForm(GARequestErrorReportingMixin, forms.Form):
+class ReviewCreditsForm(forms.Form):
     def __init__(self, request, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.request = request

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,5 +1,5 @@
 # Dependencies needed for all environments
 
-money-to-prisoners-common~=14.3.0
+money-to-prisoners-common~=15.0.0
 
 openpyxl~=3.1

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,6 +1,6 @@
 # Place development and testing dependencies here
 
-money-to-prisoners-common[testing]~=14.3.0
+money-to-prisoners-common[testing]~=15.0.0
 
 -r base.txt
 


### PR DESCRIPTION
- removed `GARequestErrorReportingMixin` from forms
- removed now unnecessary `get_ga_event_category()` method from `SearchFormV2Mixin` - this was taking advantage of an hook in `django-form-error-reporting` to customise the `category` property of the event sent to GA - it shouldn't be unnecessary now
- bumped mtp-common to version `15.0.0` (unreleased atm)
