### PR TITLE
MTP-1937: Stop trying to send data to legacy GA

### DIFF
--- a/mtp_noms_ops/assets-src/components/choose-prisons/index.js
+++ b/mtp_noms_ops/assets-src/components/choose-prisons/index.js
@@ -27,7 +27,6 @@ export var ChoosePrisons = {
     var eventCategory = 'PrisonConfirmation';
     var eventAction = 'Change';
     var eventLabel = currentPrisons;
-    Analytics.send('event', eventCategory, eventAction, eventLabel);
     Analytics.ga4SendEvent(eventCategory, eventAction, eventLabel);
 
     this.setupInputs();
@@ -85,7 +84,6 @@ export var ChoosePrisons = {
             var eventCategory = 'security.forms.preferences.ChoosePrisonForm';
             var eventAction = 'new_prison';
             var eventLabel = emptyErrorMsg;
-            Analytics.send('event', eventCategory, eventAction, eventLabel);
             Analytics.ga4SendEvent(eventCategory, eventAction, eventLabel);
           }
           noSelection = true;
@@ -106,7 +104,6 @@ export var ChoosePrisons = {
       var eventCategory = 'PrisonConfirmation';
       var eventAction = 'Save';
       var eventLabel = addedPrisons;
-      Analytics.send('event', eventCategory, eventAction, eventLabel);
       Analytics.ga4SendEvent(eventCategory, eventAction, eventLabel);
       return true;
     });
@@ -136,7 +133,6 @@ export var ChoosePrisons = {
       var eventCategory = 'PrisonConfirmation';
       var eventAction = 'Confirm';
       var eventLabel = $confirmButton.data('current-prisons') + ' > ' + newPrisonsStr;
-      Analytics.send('event', eventCategory, eventAction, eventLabel);
       Analytics.ga4SendEvent(eventCategory, eventAction, eventLabel);
     });
   },

--- a/mtp_noms_ops/assets-src/components/form-analytics/index.js
+++ b/mtp_noms_ops/assets-src/components/form-analytics/index.js
@@ -13,7 +13,6 @@ export var FormAnalytics = {
     var formId = $form.attr('id');
 
     function sendEvent (category, action, label) {
-      Analytics.send('event', category, action, label);
       Analytics.ga4SendEvent(category, action, label);
     }
 
@@ -46,7 +45,6 @@ export var FormAnalytics = {
 
         if (clickAsPageview) {
           var pageLocation = $element.attr('href').split('?')[0];
-          Analytics.rawSend('pageview', pageLocation);
           Analytics.ga4SendPageView(pageLocation);
         }
       }

--- a/mtp_noms_ops/settings/base.py
+++ b/mtp_noms_ops/settings/base.py
@@ -271,7 +271,6 @@ LOGOUT_URL = 'logout'
 OAUTHLIB_INSECURE_TRANSPORT = True
 
 ANALYTICS_REQUIRED = os.environ.get('ANALYTICS_REQUIRED', 'True') == 'True'
-GOOGLE_ANALYTICS_ID = os.environ.get('GOOGLE_ANALYTICS_ID', None)
 GA4_MEASUREMENT_ID = os.environ.get('GA4_MEASUREMENT_ID', None)
 
 ZENDESK_BASE_URL = 'https://ministryofjustice.zendesk.com'


### PR DESCRIPTION
- removed setting
- removed call to now deprecated `Analytics.js`'s legacy GA `.send()`/`.rawSend()`