### PR TITLE
Prevent scheduled prisoner location uploading outside of office hours

### DIFF
--- a/mtp_noms_ops/apps/security/forms/check.py
+++ b/mtp_noms_ops/apps/security/forms/check.py
@@ -580,7 +580,7 @@ class AssignCheckToUserForm(forms.Form):
             self.session.patch(
                 endpoint,
                 json={
-                    'assigned_to': user_id
+                    'assigned_to': user_id,
                 }
             )
             return True

--- a/mtp_noms_ops/apps/security/tests/test_forms.py
+++ b/mtp_noms_ops/apps/security/tests/test_forms.py
@@ -2835,7 +2835,7 @@ class AssignCheckToUserFormTestCase(SimpleTestCase):
             rsps.add(
                 rsps.PATCH,
                 api_url(f'/security/checks/{check_id}/'),
-                status=204,
+                status=200,
                 json={
                     'assigned_to': 5
                 }
@@ -2861,7 +2861,7 @@ class AssignCheckToUserFormTestCase(SimpleTestCase):
             rsps.add(
                 rsps.PATCH,
                 api_url(f'/security/checks/{check_id}/'),
-                status=204,
+                status=200,
                 json={
                     'assigned_to': None
                 }


### PR DESCRIPTION
…when _not in production_ environment because HMPPS Prisoner Search service is turned off and returns `503 Service Temporarily Unavailable`