### PR TITLE
MTP-1977: Redirect users back after accepting/rejecting a check.

### DIFF
--- a/mtp_noms_ops/apps/security/forms/check.py
+++ b/mtp_noms_ops/apps/security/forms/check.py
@@ -179,6 +179,11 @@ class AcceptOrRejectCheckForm(forms.Form):
     """
     fiu_action = forms.CharField(max_length=10)
 
+    redirect_url = forms.CharField(
+        required=False,
+        label=_('Redirect URL'),
+    )
+
     accept_further_details = forms.CharField(
         required=False,
         label=_('Give further details (optional)'),

--- a/mtp_noms_ops/apps/security/views/check.py
+++ b/mtp_noms_ops/apps/security/views/check.py
@@ -3,6 +3,7 @@ from typing import Optional
 from django.contrib import messages
 from django.http import Http404, HttpResponseRedirect
 from django.urls import reverse, reverse_lazy
+from django.utils.http import is_safe_url
 from django.utils.translation import gettext_lazy as _
 from django.views.generic.edit import BaseFormView, FormView
 
@@ -192,6 +193,9 @@ class AcceptOrRejectCheckView(FormView):
             {
                 'request': self.request,
                 'object_id': self.kwargs[self.id_kwarg_name],
+                'initial': {
+                    'redirect_url': self.request.GET.get('redirect_url', ''),
+                },
             },
         )
         return form_kwargs
@@ -316,6 +320,13 @@ class AcceptOrRejectCheckView(FormView):
                 ui_message = _('Credit rejected')
             messages.info(self.request, ui_message)
 
-            return HttpResponseRedirect(self.list_url)
+            redirect_url = self.request.POST.get('redirect_url', self.list_url)
+            if not is_safe_url(
+                url=redirect_url,
+                allowed_hosts={self.request.get_host()},
+                require_https=self.request.is_secure(),
+            ):
+                redirect_url = self.list_url
+            return HttpResponseRedirect(redirect_url)
 
         return super().form_valid(form)

--- a/mtp_noms_ops/apps/security/views/check.py
+++ b/mtp_noms_ops/apps/security/views/check.py
@@ -320,7 +320,7 @@ class AcceptOrRejectCheckView(FormView):
                 ui_message = _('Credit rejected')
             messages.info(self.request, ui_message)
 
-            redirect_url = self.request.POST.get('redirect_url', self.list_url)
+            redirect_url = form.cleaned_data['redirect_url']
             if not is_safe_url(
                 url=redirect_url,
                 allowed_hosts={self.request.get_host()},

--- a/mtp_noms_ops/templates/security/accept_or_reject_check.html
+++ b/mtp_noms_ops/templates/security/accept_or_reject_check.html
@@ -202,6 +202,8 @@
       {% csrf_token %}
       {% include 'govuk-frontend/components/error-summary.html' with form=form only %}
 
+      <input type="hidden" name="redirect_url" value="{{ form.redirect_url.value }}" />
+
       {% if check.status == 'pending' %}
 
         <h2 class="govuk-heading-l">{% trans 'Accept or reject this credit' %}</h2>

--- a/mtp_noms_ops/templates/security/check_list.html
+++ b/mtp_noms_ops/templates/security/check_list.html
@@ -95,7 +95,7 @@
           </td>
           <td>
             <div class="mtp-check-cell__actions">
-              <a class="govuk-button govuk-!-display-none-print" data-module="govuk-button" role="button" href="{% url 'security:resolve_check' check_id=check.id %}">{% trans 'Review' %} <span class="govuk-visually-hidden">{% trans 'credit to' %} {{ check.credit.prisoner_name }}</span></a>
+              <a class="govuk-button govuk-!-display-none-print" data-module="govuk-button" role="button" href="{% url 'security:resolve_check' check_id=check.id %}?redirect_url={{ request.get_full_path }}">{% trans 'Review' %} <span class="govuk-visually-hidden">{% trans 'credit to' %} {{ check.credit.prisoner_name }}</span></a>
               {% if view.get_class_name == 'CheckListView' %}
                 <span class="mtp-check-cell__list-status">
                   {% if check.assigned_to == form.request.user.pk %}


### PR DESCRIPTION
There are many pages of security checks to resolve. Users may be on a certain page and for whatever reason they want to be able to get back to the page they were at after accepting/rejecting a check.

The page where they were - usually the Checks list page, but it could also be in the "My list" page - is now remembered by the form. After resolving the Check the user is redirected to this page.

If for whatever reason this is missing they're taken back to the first page of the Checks list as before.