### PR TITLE
IR-1734 Point password reset links to ServiceNow

### DIFF
--- a/mtp_noms_ops/apps/views.py
+++ b/mtp_noms_ops/apps/views.py
@@ -13,7 +13,7 @@ class FAQView(TemplateView):
 
         context['breadcrumbs_back'] = reverse_lazy('login')
         context['cashbook_url'] = settings.CASHBOOK_URL
-        context['reset_password_url'] = reverse_lazy('reset_password')
+        context['reset_password_url'] = settings.SERVICENOW_PASSWORD_RESET_URL
         context['sign_up_url'] = reverse_lazy('sign-up')
 
         return context

--- a/mtp_noms_ops/settings/base.py
+++ b/mtp_noms_ops/settings/base.py
@@ -48,6 +48,11 @@ EMAILS_URL = (
     if os.environ.get('PUBLIC_EMAILS_HOST')
     else 'http://localhost:8006'
 )
+SERVICENOW_PASSWORD_RESET_URL = os.environ.get(
+    'SERVICENOW_PASSWORD_RESET_URL',
+    'https://mojprod.service-now.com/moj_sp?id=sc_cat_item'
+    '&sys_id=acc3d27e1b7e32103393a797b04bcbda&table=sc_cat_item',
+)
 SITE_URL = NOMS_OPS_URL
 DPS = os.environ.get('DPS', '/')
 

--- a/mtp_noms_ops/templates/faq.html
+++ b/mtp_noms_ops/templates/faq.html
@@ -57,9 +57,8 @@
       </h2>
 
       <p>
-        {% url 'submit_ticket' as contact_us_url %}
         {% blocktrans trimmed %}
-          To reset your password, <a href="{{ contact_us_url }}?message=Reset%20password%20isn%E2%80%99t%20working.%0A%0AMy%20username%20is%3A%20%5Bplease%20fill%20in%5D.">contact us</a>.
+          To reset your password, <a href="{{ servicenow_password_reset_url }}">contact us</a>.
         {% endblocktrans %}
       </p>
 

--- a/mtp_noms_ops/templates/mtp_auth/login.html
+++ b/mtp_noms_ops/templates/mtp_auth/login.html
@@ -78,7 +78,7 @@
             <button type="submit" class="govuk-button" data-module="govuk-button" name="signin">{% trans 'Sign in' %}</button>
           </form>
 
-          <p><a href="{% url 'reset_password' %}">{% trans 'Forgotten your password?' %}</a></p>
+          <p><a href="{{ servicenow_password_reset_url }}">{% trans 'Forgotten your password?' %}</a></p>
 
         </section>
       </div>


### PR DESCRIPTION
## What
Redirect the NOMS Ops (prisoner money intelligence) password-reset links to the new ServiceNow catalogue item, as part of migrating support logging from Zendesk to ServiceNow.

## Changes
- Add `SERVICENOW_PASSWORD_RESET_URL` setting.
- Sign-in page: 'Forgotten your password?' now links to ServiceNow.
- 'What do you need help with?' (FAQ) page: 'resetting your password' and the 'Reset password isn't working' contact-us link now point to ServiceNow.

The link URL is exposed to templates via the shared `servicenow_password_reset_url` context variable (from money-to-prisoners-common).