### PR TITLE
IR-1755 Bump money-to-prisoners-common to 21.2.7

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,5 +1,5 @@
 # Dependencies needed for all environments
 
-money-to-prisoners-common~=21.2.6
+money-to-prisoners-common~=21.2.7
 
 openpyxl~=3.1

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,6 +1,6 @@
 # Place development and testing dependencies here
 
-money-to-prisoners-common[testing]~=21.2.6
+money-to-prisoners-common[testing]~=21.2.7
 
 -r base.txt
 


### PR DESCRIPTION
Picks up common **21.2.7**, which reverts jquery `~4.0` → `~3.7`.

jquery 4.0 is ESM-only, so webpack's `ProvidePlugin({ $: 'jquery' })` bound the global `$` to the module *namespace object* instead of the jquery function → `$(...)` threw `TypeError: $ is not a function` and aborted the JS init chain. Rebuilding against 21.2.7 links jquery 3.7.1, restoring a callable `$` (and `$.proxy`).

**Confirmed:** prod `/static/app.js` currently serves jQuery v4.0.0 (broken).

Follow-up (separate ticket): proper jquery 4 migration (fix `ProvidePlugin` + replace removed APIs).