### PR TITLE
IR-1734 Revert self-service password-reset links to internal flow

### DIFF
--- a/mtp_noms_ops/apps/views.py
+++ b/mtp_noms_ops/apps/views.py
@@ -13,7 +13,7 @@ class FAQView(TemplateView):
 
         context['breadcrumbs_back'] = reverse_lazy('login')
         context['cashbook_url'] = settings.CASHBOOK_URL
-        context['reset_password_url'] = settings.SERVICENOW_PASSWORD_RESET_URL
+        context['reset_password_url'] = reverse_lazy('reset_password')
         context['sign_up_url'] = reverse_lazy('sign-up')
 
         return context

--- a/mtp_noms_ops/templates/faq.html
+++ b/mtp_noms_ops/templates/faq.html
@@ -45,9 +45,8 @@
       </h2>
 
       <p>
-        {% url 'submit_ticket' as contact_us_url %}
         {% blocktrans trimmed %}
-            To change your username, <a href="{{ contact_us_url }}?message=I%20want%20to%20change%20my%20username.%0A%0AMy%20old%20username%20%20%28usually%20your%20Quantum%20ID%29%20is%3A%20%5Bplease%20fill%20in%5D.%0A%0AMy%20new%20username%20%28usually%20your%20Quantum%20ID%29%20is%3A%20%5Bplease%20fill%20in%5D.">contact us</a>.
+            To change your username, <a href="{{ servicenow_password_reset_url }}">contact us</a>.
         {% endblocktrans %}
       </p>
 
@@ -57,9 +56,7 @@
       </h2>
 
       <p>
-        {% blocktrans trimmed %}
-          To reset your password, <a href="{{ servicenow_password_reset_url }}">contact us</a>.
-        {% endblocktrans %}
+        <a href="{{ servicenow_password_reset_url }}">{% trans 'Contact us' %}</a>
       </p>
 
 

--- a/mtp_noms_ops/templates/mtp_auth/login.html
+++ b/mtp_noms_ops/templates/mtp_auth/login.html
@@ -78,7 +78,7 @@
             <button type="submit" class="govuk-button" data-module="govuk-button" name="signin">{% trans 'Sign in' %}</button>
           </form>
 
-          <p><a href="{{ servicenow_password_reset_url }}">{% trans 'Forgotten your password?' %}</a></p>
+          <p><a href="{% url 'reset_password' %}">{% trans 'Forgotten your password?' %}</a></p>
 
         </section>
       </div>


### PR DESCRIPTION
## Why
Support saw a spike in generic password-reset cases after IR-1734 routed all password-reset links to ServiceNow — the previously self-service, email-based reset flow (`/reset-password/`) was being funnelled through support alongside account unlocks (which genuinely need manager approval). This puts the self-service links back while keeping ServiceNow for the things that should stay there.

## Changes
- **Sign-in "Forgotten your password?"** → internal `/reset-password/` flow
- **Get help / "resetting your password"** (link 1) → internal `/reset-password/` flow
- **Get help / "change username → contact us"** (link 3) → off Zendesk, onto the ServiceNow URL (drops the `?message=` prefill)
- **Get help / "Reset password isn't working"** (link 4) → trimmed to a lone **Contact us** link (still ServiceNow)

`SERVICENOW_PASSWORD_RESET_URL` is retained (still used by Get help links 3 & 4). No `money-to-prisoners-common` change.

## Notes
- Welsh translations for the two changed Get help strings are an English-fallback follow-up (via Transifex), consistent with the previous change.
- Merging deploys to **test** only for the support team to validate.