### PR TITLE
IR-1734 Register reworded Get help strings for Welsh translation

### DIFF
--- a/mtp_noms_ops/translations/cy/LC_MESSAGES/django.po
+++ b/mtp_noms_ops/translations/cy/LC_MESSAGES/django.po
@@ -1081,14 +1081,20 @@ msgstr "Lleoliad carcharor - gweinyddol"
 msgid "Go to the homepage"
 msgstr "Ewch i dudalen gartref"
 
+#: templates/faq.html:49
+#, python-format
+msgid "To change your username, <a href=\"%(servicenow_password_reset_url)s\">contact us</a>."
+msgstr ""
+
+#: templates/faq.html:59
+msgid "Contact us"
+msgstr "Cysylltu â ni"
+
 #~ msgid "Change password"
 #~ msgstr "Newid cyfrinair"
 
 #~ msgid "Sign out"
 #~ msgstr "Allgofnodi"
-
-#~ msgid "Contact us"
-#~ msgstr "Cysylltu â ni"
 
 #~ msgid "Update list"
 #~ msgstr "Diweddaru'r rhestr"

--- a/mtp_noms_ops/translations/en_GB/LC_MESSAGES/django.po
+++ b/mtp_noms_ops/translations/en_GB/LC_MESSAGES/django.po
@@ -1064,3 +1064,12 @@ msgstr ""
 #: utils.py:48
 msgid "Go to the homepage"
 msgstr ""
+
+#: templates/faq.html:49
+#, python-format
+msgid "To change your username, <a href=\"%(servicenow_password_reset_url)s\">contact us</a>."
+msgstr ""
+
+#: templates/faq.html:59
+msgid "Contact us"
+msgstr ""


### PR DESCRIPTION
## Why
Follow-up to the ServiceNow-link revert (#638). Two Get help source strings changed and weren't in the translation catalogs, so they'd show as English on the Welsh site. This registers them so they can be translated via **Transifex**.

## Changes
Adds the two strings to `en_GB` (source) and `cy` (Welsh) `django.po`:
- `To change your username, <a href="…">contact us</a>.` — the link href changed (Zendesk → ServiceNow)
- `Contact us` — the new lone link that replaced the "Reset password isn't working" sentence

Welsh `msgstr` is left **empty for professional translators** via Transifex, with the one exception of reinstating the previously-translated `Contact us` → `Cysylltu â ni` (moved from an obsolete entry back to active).

## Notes
- Deliberately scoped to just the two IR-1734 strings — a full `makemessages` regen would churn ~200 line-number references and pull in unrelated accumulated strings. A broader catalog refresh is better handled as its own hygiene task.
- No functional/runtime change; source-catalog only. `.mo` files are compiled at build time.